### PR TITLE
Remove empty Logger.log

### DIFF
--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -33,7 +33,6 @@ defmodule LoggerJSON.Plug do
     Conn.register_before_send(conn, fn conn ->
       diff = format_time(System.monotonic_time() - start)
       metadata = request_metadata(conn, diff)
-      Logger.log(level, "", metadata)
       conn
     end)
   end


### PR DESCRIPTION
For every `LoggerJSON.Plug.call/2` the module is calling `Logger.log/3`, producing an empty entry in the log systems.