### PR TITLE
Log crash reason and initial call metadata gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache:
   directories:
   - deps
 elixir:
-  - 1.6.4
+  - 1.7.3
 otp_release:
-  - 20.0
+  - 21.0.8
 env:
   global:
     - MIX_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache:
   directories:
   - deps
 elixir:
-  - 1.7.3
+  - 1.6.4
 otp_release:
-  - 21.0.8
+  - 20.0
 env:
   global:
     - MIX_ENV=test

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -8,7 +8,7 @@
       checks: [
         {Credo.Check.Design.TagTODO, exit_status: 0},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
-        {Credo.Check.Readability.Specs, exit_status: 0},
+        {Credo.Check.Readability.Specs, exit_status: 0}
       ]
     }
   ]

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -322,7 +322,7 @@ defmodule LoggerJSON do
 
   def take_metadata(metadata, :all) do
     metadata
-    |> Keyword.drop([:pid, :file, :line, :function, :module])
+    |> Keyword.drop([:pid, :file, :line, :function, :module, :crash_reason, :initial_call])
     |> Enum.into(%{})
   end
 

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -108,14 +108,12 @@ defmodule LoggerJSON do
   Notice that settings this valie below `compile_time_purge_level` would not work,
   because Logger calls would be already stripped at compile-time.
   """
-  def configure_log_level!(nil),
-    do: :ok
+  def configure_log_level!(nil), do: :ok
 
   def configure_log_level!(level) when level in ["debug", "info", "warn", "error"],
     do: Logger.configure(level: String.to_atom(level))
 
-  def configure_log_level!(level) when is_atom(level),
-    do: Logger.configure(level: level)
+  def configure_log_level!(level) when is_atom(level), do: Logger.configure(level: level)
 
   def configure_log_level!(level) do
     raise ArgumentError,

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -33,7 +33,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
 
   defp format_metadata(md, md_keys) do
     md
-    |> Keyword.drop([:pid, :file, :line, :function, :module, :ansi_color, :application, :crash_reason])
+    |> Keyword.drop([:pid, :file, :line, :function, :module, :ansi_color, :application, :crash_reason, :initial_call])
     |> LoggerJSON.take_metadata(md_keys)
     |> maybe_put_initial_call(md[:initial_call])
     |> maybe_put_crash_reason(md[:crash_reason])

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -33,8 +33,24 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
 
   defp format_metadata(md, md_keys) do
     md
-    |> Keyword.drop([:pid, :file, :line, :function, :module, :ansi_color, :application])
+    |> Keyword.drop([
+      :pid, :file, :line, :function, :module, :ansi_color,
+      :application, :crash_reason])
     |> LoggerJSON.take_metadata(md_keys)
+    |> maybe_put_initial_call(md[:initial_call])
+    |> maybe_put_crash_reason(md[:crash_reason])
+  end
+
+  defp maybe_put_initial_call(md, nil), do: md
+  defp maybe_put_initial_call(md, {module, fun, arity}) do
+    Map.put(md, :initial_call, "#{module}.#{fun}/#{arity}")
+  end
+
+  defp maybe_put_crash_reason(md, nil), do: md
+  defp maybe_put_crash_reason(md, {reason, stacktrace}) do
+    md
+    |> Map.put(:crash_reason, inspect(reason))
+    |> Map.put(:crash_reason_stacktrace, inspect(stacktrace))
   end
 
   # RFC3339 UTC "Zulu" format

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -33,20 +33,20 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
 
   defp format_metadata(md, md_keys) do
     md
-    |> Keyword.drop([
-      :pid, :file, :line, :function, :module, :ansi_color,
-      :application, :crash_reason])
+    |> Keyword.drop([:pid, :file, :line, :function, :module, :ansi_color, :application, :crash_reason])
     |> LoggerJSON.take_metadata(md_keys)
     |> maybe_put_initial_call(md[:initial_call])
     |> maybe_put_crash_reason(md[:crash_reason])
   end
 
   defp maybe_put_initial_call(md, nil), do: md
+
   defp maybe_put_initial_call(md, {module, fun, arity}) do
     Map.put(md, :initial_call, "#{module}.#{fun}/#{arity}")
   end
 
   defp maybe_put_crash_reason(md, nil), do: md
+
   defp maybe_put_crash_reason(md, {reason, stacktrace}) do
     md
     |> Map.put(:crash_reason, inspect(reason))

--- a/test/unit/logger_json/ecto_test.exs
+++ b/test/unit/logger_json/ecto_test.exs
@@ -36,13 +36,14 @@ defmodule LoggerJSON.EctoTest do
       "jsonPayload" => %{
         "message" => "done",
         "metadata" => %{
-          "application" => "logger_json",
-          "connection_pid" => nil,
           "decode_time" => 0.5,
           "duration" => 2.7,
           "query_time" => 2.1,
           "queue_time" => 0.1
         }
+      },
+      "labels" => %{
+        "application_name" => "logger_json"
       }
     } = Jason.decode!(log)
   end
@@ -60,13 +61,14 @@ defmodule LoggerJSON.EctoTest do
       "jsonPayload" => %{
         "message" => "done",
         "metadata" => %{
-          "application" => "logger_json",
-          "connection_pid" => nil,
           "decode_time" => 0.5,
           "duration" => 2.7,
           "query_time" => 2.1,
           "queue_time" => 0.1
         }
+      },
+      "labels" => %{
+        "application_name" => "logger_json",
       }
     } = Jason.decode!(log)
   end

--- a/test/unit/logger_json/ecto_test.exs
+++ b/test/unit/logger_json/ecto_test.exs
@@ -68,7 +68,7 @@ defmodule LoggerJSON.EctoTest do
         }
       },
       "labels" => %{
-        "application_name" => "logger_json",
+        "application_name" => "logger_json"
       }
     } = Jason.decode!(log)
   end

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -34,7 +34,6 @@ defmodule LoggerJSON.PlugTest do
              "jsonPayload" => %{
                "message" => "",
                "metadata" => %{
-                 "application" => "logger_json",
                  "client" => %{"ip" => "127.0.0.1", "user_agent" => nil, "version" => nil},
                  "connection" => %{
                    "method" => "GET",
@@ -47,6 +46,9 @@ defmodule LoggerJSON.PlugTest do
                  "runtime" => %{},
                  "system" => %{"hostname" => _, "pid" => _}
                }
+             },
+             "labels" => %{
+               "application_name" => "logger_json"
              }
            } = Jason.decode!(log)
 
@@ -62,7 +64,6 @@ defmodule LoggerJSON.PlugTest do
              "jsonPayload" => %{
                "message" => "",
                "metadata" => %{
-                 "application" => "logger_json",
                  "client" => %{"ip" => "127.0.0.1", "user_agent" => nil, "version" => nil},
                  "connection" => %{
                    "method" => "GET",
@@ -75,6 +76,9 @@ defmodule LoggerJSON.PlugTest do
                  "runtime" => %{"controller" => "Elixir.MyController", "action" => "foo"},
                  "system" => %{"hostname" => _, "pid" => _}
                }
+             },
+             "labels" => %{
+               "application_name" => "logger_json"
              }
            } = Jason.decode!(log)
   end
@@ -100,7 +104,6 @@ defmodule LoggerJSON.PlugTest do
              "jsonPayload" => %{
                "message" => "",
                "metadata" => %{
-                 "application" => "logger_json",
                  "client" => %{"ip" => "127.0.0.10", "user_agent" => "chrome", "version" => "2017-01-01"},
                  "connection" => %{
                    "method" => "GET",
@@ -113,6 +116,9 @@ defmodule LoggerJSON.PlugTest do
                  "runtime" => %{},
                  "system" => %{"hostname" => _, "pid" => _}
                }
+             },
+             "labels" => %{
+               "application_name" => "logger_json"
              }
            } = Jason.decode!(log)
   end


### PR DESCRIPTION
Closes #10 

This PR adds graceful handling of non-serializable metadata coming from OTP crash reports.

Context: https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger.ex#L285