### PR TITLE
Address use of Jason.Helpers.json_map

### DIFF
--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -90,10 +90,8 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
 
   # RFC3339 UTC "Zulu" format
   defp format_timestamp({date, time}) do
-    [format_date(date), format_time(time)]
-    |> Enum.map(&IO.iodata_to_binary/1)
-    |> Enum.join("T")
-    |> Kernel.<>("Z")
+    [format_date(date), ?T, format_time(time), ?Z]
+    |> IO.iodata_to_binary()
   end
 
   # Description can be found in Google Cloud Logger docs;

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -17,16 +17,22 @@ if Code.ensure_loaded?(Plug) do
     @doc false
     def build_metadata(conn, latency, client_version_header) do
       latency_seconds = native_to_seconds(latency)
+      request_method = conn.method
+      request_url = request_url(conn)
+      status = conn.status
+      user_agent = LoggerJSON.Plug.get_header(conn, "user-agent")
+      remote_ip = remote_ip(conn)
+      referer = LoggerJSON.Plug.get_header(conn, "referer")
 
       [
         httpRequest:
           json_map(
-            requestMethod: conn.method,
-            requestUrl: request_url(conn),
-            status: conn.status,
-            userAgent: LoggerJSON.Plug.get_header(conn, "user-agent"),
-            remoteIp: remote_ip(conn),
-            referer: LoggerJSON.Plug.get_header(conn, "referer"),
+            requestMethod: request_method,
+            requestUrl: request_url,
+            status: status,
+            userAgent: user_agent,
+            remoteIp: remote_ip,
+            referer: referer,
             latency: latency_seconds
           )
       ] ++ client_metadata(conn, client_version_header) ++ phoenix_metadata(conn) ++ node_metadata()


### PR DESCRIPTION
Closes #27.  

This pull-request addresses:

- The problem surrounding `Jason.Helpers.json_map` described in the issue above, and
- Makes `LoggerJSON.Formatters.GoogleCloudLogger.format_time/1` slightly more efficient