### PR TITLE
Add conn.request_path to google_cloud_logger format

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ By-default, generated JSON is compatible with
       "latency":"0.350s",
       "remoteIp":"::ffff:10.142.0.2",
       "requestMethod":"GET",
+      "requestPath":"/",
       "requestUrl":"http://10.16.0.70/",
       "status":200,
       "userAgent":"kube-probe/1.10+"

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -18,6 +18,7 @@ if Code.ensure_loaded?(Plug) do
     def build_metadata(conn, latency, client_version_header) do
       latency_seconds = native_to_seconds(latency)
       request_method = conn.method
+      request_path = conn.request_path
       request_url = request_url(conn)
       status = conn.status
       user_agent = LoggerJSON.Plug.get_header(conn, "user-agent")
@@ -31,6 +32,7 @@ if Code.ensure_loaded?(Plug) do
           httpRequest:
             json_map(
               requestMethod: request_method,
+              requestPath: request_path,
               requestUrl: request_url,
               status: status,
               userAgent: user_agent,

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -39,6 +39,7 @@ defmodule LoggerJSON.PlugTest do
                "referer" => nil,
                "remoteIp" => "127.0.0.1",
                "requestMethod" => "GET",
+               "requestPath" => "/",
                "requestUrl" => "http://www.example.com/",
                "status" => 200,
                "userAgent" => nil


### PR DESCRIPTION
Adding the request_path allows this value to be indexed
and filtered upon. Although the request_url attribute includes
the request path, the hostname in the request_url may not be a static value which
can make filtering on the request_path portion slow. Including the
request path as it's own top level attribute resolves this problem.

Resolves #32 