### PR TITLE
Add filtered params to plug metadata output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,66 +24,65 @@ After adding this back-end you may also be interested in [redirecting otp and sa
 By-default, generated JSON is compatible with
 [Google Cloud Logger LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) format:
 
-  ```json
-  {
-    "log":"hello",
-    "logging.googleapis.com/sourceLocation":{
-      "file":"/os/logger_json/test/unit/logger_json_test.exs",
-      "function":"Elixir.LoggerJSONTest.test metadata can be configured/1",
-      "line":71
-    },
-    "severity":"DEBUG",
-    "time":"2018-10-19T01:10:49.582Z",
-    "user_id":13
-  }
-  ```
+```json
+{
+  "log": "hello",
+  "logging.googleapis.com/sourceLocation": {
+    "file": "/os/logger_json/test/unit/logger_json_test.exs",
+    "function": "Elixir.LoggerJSONTest.test metadata can be configured/1",
+    "line": 71
+  },
+  "severity": "DEBUG",
+  "time": "2018-10-19T01:10:49.582Z",
+  "user_id": 13
+}
+```
 
-  Log entry in Google Cloud Logger would looks something like this:
+Log entry in Google Cloud Logger would looks something like this:
 
-
-  ```json
-  {
-    "httpRequest":{
-      "latency":"0.350s",
-      "remoteIp":"::ffff:10.142.0.2",
-      "requestMethod":"GET",
-      "requestPath":"/",
-      "requestUrl":"http://10.16.0.70/",
-      "status":200,
-      "userAgent":"kube-probe/1.10+"
+```json
+{
+  "httpRequest": {
+    "latency": "0.350s",
+    "remoteIp": "::ffff:10.142.0.2",
+    "requestMethod": "GET",
+    "requestPath": "/",
+    "requestUrl": "http://10.16.0.70/",
+    "status": 200,
+    "userAgent": "kube-probe/1.10+"
+  },
+  "insertId": "1g64u74fgmqqft",
+  "jsonPayload": {
+    "log": "",
+    "phoenix": {
+      "action": "index",
+      "controller": "Elixir.MyApp.Web.PageController"
     },
-    "insertId":"1g64u74fgmqqft",
-    "jsonPayload":{
-      "log":"",
-      "phoenix":{
-        "action":"index",
-        "controller":"Elixir.MyApp.Web.PageController",
-      },
-      "request_id":"2lfbl1r3m81c40e5v40004c2",
-      "vm":{
-        "hostname":"myapp-web-66979fc-vbk4q",
-        "pid":1,
-      }
-    },
-    "logName":"projects/hammer-staging/logs/stdout",
-    "metadata":{
-      "systemLabels":{},
-      "userLabels":{}
-    },
-    "operation":{
-      "id":"2lfbl1r3m81c40e5v40004c2"
-    },
-    "receiveTimestamp":"2018-10-18T14:33:35.515253723Z",
-    "resource":{},
-    "severity":"INFO",
-    "sourceLocation":{
-      "file":"iex",
-      "function":"Elixir.LoggerJSON.Plug.call/2",
-      "line":"36"
-    },
-    "timestamp":"2018-10-18T14:33:33.263Z"
-  }
-  ```
+    "request_id": "2lfbl1r3m81c40e5v40004c2",
+    "vm": {
+      "hostname": "myapp-web-66979fc-vbk4q",
+      "pid": 1
+    }
+  },
+  "logName": "projects/hammer-staging/logs/stdout",
+  "metadata": {
+    "systemLabels": {},
+    "userLabels": {}
+  },
+  "operation": {
+    "id": "2lfbl1r3m81c40e5v40004c2"
+  },
+  "receiveTimestamp": "2018-10-18T14:33:35.515253723Z",
+  "resource": {},
+  "severity": "INFO",
+  "sourceLocation": {
+    "file": "iex",
+    "function": "Elixir.LoggerJSON.Plug.call/2",
+    "line": "36"
+  },
+  "timestamp": "2018-10-18T14:33:33.263Z"
+}
+```
 
 You can change this structure by implementing `LoggerJSON.Formatter` behaviour and passing module
 name to `:formatter` config option. Example module can be found in `LoggerJSON.Formatters.GoogleCloudLogger`.
@@ -97,54 +96,64 @@ config :logger_json, :backend,
 
 It's [available on Hex](https://hex.pm/packages/logger_json), the package can be installed as:
 
-  1. Add `:logger_json` and `:jason` to your list of dependencies in `mix.exs`:
+1. Add `:logger_json` and `:jason` to your list of dependencies in `mix.exs`:
 
-  ```ex
-  def deps do
-    [{:logger_json, "~> 3.0"}]
-  end
-  ```
+```ex
+def deps do
+  [{:logger_json, "~> 3.0"}]
+end
+```
 
-  2. Ensure `logger_json` and `:jason` is started before your application:
+2. Ensure `logger_json` and `:jason` is started before your application:
 
-  ```ex
-  def application do
-    [extra_applications: [:jason, :logger_json]]
-  end
-  ```
+```ex
+def application do
+  [extra_applications: [:jason, :logger_json]]
+end
+```
 
-  3. Set configuration in your `config/config.exs`:
+3. Set configuration in your `config/config.exs`:
 
-  ```ex
-  config :logger_json, :backend,
-    metadata: :all
-  ```
+```ex
+config :logger_json, :backend,
+  metadata: :all
+```
 
-  Some integrations (for eg. Plug) uses `metadata` to log request
-  and response parameters. You can reduce log size by replacing `:all`
-  (which means log all) with a list of the ones that you actually need.
+Some integrations (for eg. Plug) uses `metadata` to log request
+and response parameters. You can reduce log size by replacing `:all`
+(which means log all) with a list of the ones that you actually need.
 
-  4. Replace default Logger `:console` back-end with `LoggerJSON`:
+4. Replace default Logger `:console` back-end with `LoggerJSON`:
 
-  ```ex
-  config :logger,
-    backends: [LoggerJSON]
-  ```
+```ex
+config :logger,
+  backends: [LoggerJSON]
+```
 
-  5. Optionally. Log requests and responses by replacing a `Plug.Logger` in your endpoint with a:
+5. Optionally. Log requests and responses by replacing a `Plug.Logger` in your endpoint with a:
 
-  ```ex
-  plug LoggerJSON.Plug
-  ```
+```ex
+plug LoggerJSON.Plug
+```
 
-  6. Optionally. Log Ecto queries via Plug:
+It accepts some parameters:
 
-  ```ex
-  config :my_app, MyApp.Repo,
-    adapter: Ecto.Adapters.Postgres,
-    ...
-    loggers: [{LoggerJSON.Ecto, :log, [:info]}]
-  ```
+- :log - Specify the log level. Default: :info
+- :version_header - Specify the header name that identify the API version. Default: "x-api-version"
+- :metadata_formatter - Specify the module that will format the Plug metadata. Default: LoggerJSON.MetadataFormatters.GoogleCloudLogger. Available options:
+  - LoggerJSON.MetadataFormatters.GoogleCloudLogger
+  - LoggerJSON.MetadataFormatters.ELK
+  - Your own module
+- :filter_parameters - Specify the list of filtered parameters to be discarded before output log. Default: []
+
+6. Optionally. Log Ecto queries via Plug:
+
+```ex
+config :my_app, MyApp.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  ...
+  loggers: [{LoggerJSON.Ecto, :log, [:info]}]
+```
 
 ## Dynamic configuration
 

--- a/lib/logger_json/params_filter.ex
+++ b/lib/logger_json/params_filter.ex
@@ -1,0 +1,26 @@
+defmodule LoggerJSON.ParamsFilter do
+  @moduledoc """
+  Filter params by key replacing the content by `FILTERED`.
+  Inspired by Phoenix implementation: https://github.com/phoenixframework/phoenix/blob/v1.4.16/lib/phoenix/logger.ex#L73-L91
+  """
+
+  def discard_values(%{__struct__: mod} = struct, _params) when is_atom(mod) do
+    struct
+  end
+
+  def discard_values(%{} = map, params) do
+    Enum.into(map, %{}, fn {k, v} ->
+      if is_binary(k) and String.contains?(k, params) do
+        {k, "[FILTERED]"}
+      else
+        {k, discard_values(v, params)}
+      end
+    end)
+  end
+
+  def discard_values([_ | _] = list, params) do
+    Enum.map(list, &discard_values(&1, params))
+  end
+
+  def discard_values(other, _params), do: other
+end

--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -31,16 +31,17 @@ if Code.ensure_loaded?(Plug) do
       level = Keyword.get(opts, :log, :info)
       client_version_header = Keyword.get(opts, :version_header, "x-api-version")
       metadata_formatter = Keyword.get(opts, :metadata_formatter, MetadataFormatters.GoogleCloudLogger)
-      {level, metadata_formatter, client_version_header}
+      filter_parameters = Keyword.get(opts, :filter_parameters, [])
+      {level, metadata_formatter, client_version_header, filter_parameters}
     end
 
     @impl true
-    def call(conn, {level, metadata_formatter, client_version_header}) do
+    def call(conn, {level, metadata_formatter, client_version_header, filter_parameters}) do
       start = System.monotonic_time()
 
       Conn.register_before_send(conn, fn conn ->
         latency = System.monotonic_time() - start
-        metadata = metadata_formatter.build_metadata(conn, latency, client_version_header)
+        metadata = metadata_formatter.build_metadata(conn, latency, client_version_header, filter_parameters)
         Logger.log(level, "", metadata)
         conn
       end)

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -15,7 +15,7 @@ if Code.ensure_loaded?(Plug) do
     @nanoseconds_in_second System.convert_time_unit(1, :second, :nanosecond)
 
     @doc false
-    def build_metadata(conn, latency, client_version_header) do
+    def build_metadata(conn, latency, client_version_header, filter_parameters) do
       latency_seconds = native_to_seconds(latency)
       request_method = conn.method
       request_path = conn.request_path
@@ -34,6 +34,7 @@ if Code.ensure_loaded?(Plug) do
               requestMethod: request_method,
               requestPath: request_path,
               requestUrl: request_url,
+              params: fetch_params(conn.params, filter_parameters),
               status: status,
               userAgent: user_agent,
               remoteIp: remote_ip,
@@ -87,5 +88,9 @@ if Code.ensure_loaded?(Plug) do
 
       {hostname, vm_pid}
     end
+
+    defp fetch_params(%Plug.Conn.Unfetched{aspect: :params}, _filter_parameters), do: %{}
+
+    defp fetch_params(params, filter_parameters), do: LoggerJSON.ParamsFilter.discard_values(params, filter_parameters)
   end
 end

--- a/test/unit/logger_json/params_filter_test.exs
+++ b/test/unit/logger_json/params_filter_test.exs
@@ -1,0 +1,47 @@
+defmodule LoggerJSON.ParamsFilterTest do
+  use ExUnit.Case, async: true
+
+  alias LoggerJSON.ParamsFilter
+
+  describe "discart_values" do
+    test "in top level map" do
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{"foo" => "bar", "password" => "[FILTERED]"}
+    end
+
+    test "when a map has secret key" do
+      values = %{"foo" => "bar", "map" => %{"password" => "should_not_show"}}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+    end
+
+    test "when a list has a map with secret" do
+      values = %{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+    end
+
+    test "does not filter structs" do
+      values = %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+      values = %{"foo" => "bar", "file" => %{__struct__: "s"}}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+    end
+
+    test "does not fail on atomic keys" do
+      values = %{:foo => "bar", "password" => "should_not_show"}
+
+      assert ParamsFilter.discard_values(values, ["password"]) ==
+               %{:foo => "bar", "password" => "[FILTERED]"}
+    end
+  end
+end

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -7,7 +7,7 @@ defmodule LoggerJSON.PlugTest do
   defmodule MyPlug do
     use Plug.Builder
 
-    plug(LoggerJSON.Plug)
+    plug(LoggerJSON.Plug, filter_parameters: ["foo"])
     plug(:passthrough)
 
     defp passthrough(conn, _) do
@@ -28,7 +28,7 @@ defmodule LoggerJSON.PlugTest do
 
     log =
       capture_io(:standard_error, fn ->
-        call(conn(:get, "/"))
+        call(conn(:post, "/?a=b", %{"foo" => "bar"}))
         Logger.flush()
       end)
 
@@ -38,9 +38,10 @@ defmodule LoggerJSON.PlugTest do
                "latency" => latency,
                "referer" => nil,
                "remoteIp" => "127.0.0.1",
-               "requestMethod" => "GET",
+               "requestMethod" => "POST",
                "requestPath" => "/",
                "requestUrl" => "http://www.example.com/",
+               "params" => %{"a" => "b", "foo" => "[FILTERED]"},
                "status" => 200,
                "userAgent" => nil
              },


### PR DESCRIPTION
Adding HTTP params to plug metadata with filter sensitive values feature (copy and paste from Phoenix).

`README` as formatted and I added the options accepted by plug. I could keep only the options accepted reverting the format if you want.