### PR TITLE
Ensure custom metadata with PIDs do not crash

### DIFF
--- a/lib/logger_json/jason_encoders.ex
+++ b/lib/logger_json/jason_encoders.ex
@@ -1,0 +1,9 @@
+if Code.ensure_loaded?(Jason) do
+  # For certain crashes eg some structures containing PIDs that were not encoded properly
+  # resulting in UndefinedProtocol crashes
+  defimpl Jason.Encoder, for: PID do
+    def encode(value, _opts) do
+      value |> inspect() |> Jason.encode!()
+    end
+  end
+end

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -263,6 +263,19 @@ defmodule LoggerJSONGoogleTest do
     assert log["error"]["reason"] == "{:socket_closed_unexpectedly, []}"
   end
 
+  test "logs metadata with crash containing PIDs" do
+    Logger.configure_backend(LoggerJSON, metadata: [:ancestors])
+    Logger.metadata(ancestors: [:process, self()])
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert log["ancestors"]
+    assert log["ancestors"] == ["process", "#{inspect(self())}"]
+  end
+
   test "logs initial call when present" do
     Logger.configure_backend(LoggerJSON, metadata: [:initial_call])
     Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []}, initial_call: {Foo, :bar, 3})


### PR DESCRIPTION
While using default Google Stackdriver formater I was experiencing issues with `UndefinedProtocol` for `PID` when using `jason` encoder. This happened in crashes (`:ancestors` field) and resulted in errors. Using `Jason.Encoder` for `PID` fixes the problem.

Thanks for your `logger_json` as structured logging significantly improved our ability to find and identify issues.