### PR TITLE
Use IO.chardata_to_string/1 instead of IO.iodata_to_binary/1

### DIFF
--- a/lib/logger_json/formatters/basic_logger.ex
+++ b/lib/logger_json/formatters/basic_logger.ex
@@ -16,7 +16,7 @@ defmodule LoggerJSON.Formatters.BasicLogger do
     json_map(
       time: FormatterUtils.format_timestamp(ts),
       severity: Atom.to_string(level),
-      message: IO.iodata_to_binary(msg),
+      message: IO.chardata_to_string(msg),
       metadata: format_metadata(md, md_keys)
     )
   end

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -31,7 +31,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
         %{
           time: FormatterUtils.format_timestamp(ts),
           severity: unquote(gcp_level),
-          message: IO.iodata_to_binary(msg)
+          message: IO.chardata_to_string(msg)
         },
         format_metadata(md, md_keys)
       )
@@ -43,7 +43,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
       %{
         time: FormatterUtils.format_timestamp(ts),
         severity: "DEFAULT",
-        message: IO.iodata_to_binary(msg)
+        message: IO.chardata_to_string(msg)
       },
       format_metadata(md, md_keys)
     )

--- a/test/unit/logger_json_basic_test.exs
+++ b/test/unit/logger_json_basic_test.exs
@@ -64,4 +64,15 @@ defmodule LoggerJSONBasicTest do
       assert %{} == log["metadata"]
     end
   end
+
+  test "logs chardata messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([?α, ?β, ?ω]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "αβω"} = log
+  end
 end

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -85,6 +85,17 @@ defmodule LoggerJSONGoogleTest do
     assert %{"message" => "hello"} = log
   end
 
+  test "logs chardata messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([?π, ?α, ?β]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "παβ"} = log
+  end
+
   test "log message does not break escaping" do
     Logger.configure_backend(LoggerJSON, metadata: :all)
 


### PR DESCRIPTION
> the message: this is usually chardata, but in some cases it may contain invalid data. Since the formatting function should never fail, you need to prepare for the message being anything

from : https://hexdocs.pm/logger/Logger.html#module-custom-formatting

This PR fixes a crash when try to log [IO.chardata()](https://hexdocs.pm/elixir/IO.html#module-chardata).

### Crash reproduction

```
Interactive Elixir (1.10.3) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> require Logger
Logger
iex(2)> Logger.debug([?π])
:ok
iex(3)> :gen_event handler LoggerJSON installed in Logger terminating
** (exit) an exception was raised:
    ** (ArgumentError) argument error
        :erlang.iolist_to_binary([960])
        (logger_json 4.0.0) lib/logger_json/formatters/basic_logger.ex:19: LoggerJSON.Formatters.BasicLogger.format_event/5
        (logger_json 4.0.0) lib/logger_json.ex:293: LoggerJSON.format_event/5
        (logger_json 4.0.0) lib/logger_json.ex:241: LoggerJSON.log_event/5
        (logger_json 4.0.0) lib/logger_json.ex:143: LoggerJSON.handle_event/2
        (stdlib 3.12.1) gen_event.erl:577: :gen_event.server_update/4
        (stdlib 3.12.1) gen_event.erl:559: :gen_event.server_notify/4
        (stdlib 3.12.1) gen_event.erl:300: :gen_event.handle_msg/6
        (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```