### PR TITLE
Fix incorrect field name in module document

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -8,7 +8,7 @@ if Code.ensure_loaded?(Plug) do
       * `phoenix.controller` - Phoenix controller that processed the request;
       * `phoenix.action` - Phoenix action that processed the request;
       * `node.hostname` - node hostname;
-      * `node.pid` - Erlang VM process identifier.
+      * `node.vm_pid` - Erlang VM process identifier.
     """
     import Jason.Helpers, only: [json_map: 1]
 


### PR DESCRIPTION
Change `node.pid` into `node.vm_pid`.