### PR TITLE
Fix incorrect field name in module document

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/elk.ex
+++ b/lib/logger_json/plug/metadata_formatters/elk.ex
@@ -12,7 +12,7 @@ if Code.ensure_loaded?(Plug) do
       * `client.ip' - value of `X-Forwarded-For` header if present, otherwise - remote IP of a connected client;
       * `client.api_version' - version of API that was requested by a client;
       * `node.hostname` - system hostname;
-      * `node.pid` - Erlang VM process identifier;
+      * `node.vm_pid` - Erlang VM process identifier;
       * `phoenix.controller` - Phoenix controller that processed the request;
       * `phoenix.action` - Phoenix action that processed the request;
       * `latency_μs` - time in microseconds taken to process the request.


### PR DESCRIPTION
Change `node.pid` into `node.vm_pid` in MetadataFormatters.ELK.