### PR TITLE
Add better formatting protections for non-Jason friendly metadata

### DIFF
--- a/lib/logger_json/formatters/basic_logger.ex
+++ b/lib/logger_json/formatters/basic_logger.ex
@@ -5,7 +5,7 @@ defmodule LoggerJSON.Formatters.BasicLogger do
 
   import Jason.Helpers, only: [json_map: 1]
 
-  alias LoggerJSON.FormatterUtils
+  alias LoggerJSON.{FormatterUtils, JasonSafeFormatter}
 
   @behaviour LoggerJSON.Formatter
 
@@ -25,5 +25,6 @@ defmodule LoggerJSON.Formatters.BasicLogger do
     md
     |> LoggerJSON.take_metadata(md_keys, @processed_metadata_keys)
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))
+    |> JasonSafeFormatter.format()
   end
 end

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -4,7 +4,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
   """
   import Jason.Helpers, only: [json_map: 1]
 
-  alias LoggerJSON.FormatterUtils
+  alias LoggerJSON.{FormatterUtils, JasonSafeFormatter}
 
   @behaviour LoggerJSON.Formatter
 
@@ -54,6 +54,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))
     |> FormatterUtils.maybe_put(:"logging.googleapis.com/sourceLocation", format_source_location(md))
     |> FormatterUtils.maybe_put(:"logging.googleapis.com/operation", format_operation(md))
+    |> JasonSafeFormatter.format()
   end
 
   defp format_operation(md) do

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -51,10 +51,10 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
 
   defp format_metadata(md, md_keys) do
     LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys)
+    |> JasonSafeFormatter.format()
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))
     |> FormatterUtils.maybe_put(:"logging.googleapis.com/sourceLocation", format_source_location(md))
     |> FormatterUtils.maybe_put(:"logging.googleapis.com/operation", format_operation(md))
-    |> JasonSafeFormatter.format()
   end
 
   defp format_operation(md) do

--- a/lib/logger_json/jason_safe_formatter.ex
+++ b/lib/logger_json/jason_safe_formatter.ex
@@ -20,6 +20,10 @@ defmodule LoggerJSON.JasonSafeFormatter do
     data
   end
 
+  def format(nil), do: nil
+  def format(true), do: true
+  def format(false), do: false
+
   def format(%mod{} = data) do
     if jason_implemented?(mod) do
       data

--- a/lib/logger_json/jason_safe_formatter.ex
+++ b/lib/logger_json/jason_safe_formatter.ex
@@ -23,6 +23,7 @@ defmodule LoggerJSON.JasonSafeFormatter do
   def format(nil), do: nil
   def format(true), do: true
   def format(false), do: false
+  def format(data) when is_atom(data), do: data
 
   def format(%mod{} = data) do
     if jason_implemented?(mod) do

--- a/lib/logger_json/jason_safe_formatter.ex
+++ b/lib/logger_json/jason_safe_formatter.ex
@@ -1,6 +1,10 @@
 defmodule LoggerJSON.JasonSafeFormatter do
   @moduledoc """
-  Produces metadata that is "safe" for calling Jason.encode!() on without errors.
+  Utilities for converting metadata into datastructures that can be safely passed to Jason.encode!/1
+  """
+
+  @doc """
+  Produces metadata that is "safe" for calling Jason.encode!/1 on without errors.
   This means that unexpected Logger metadata won't cause logging crashes.
   Current formatting is...
   - Maps: as is
@@ -11,6 +15,7 @@ defmodule LoggerJSON.JasonSafeFormatter do
   - Keyword lists: converted to Maps
   - everything else: inspected
   """
+  @spec format(any()) :: any()
   def format(%Jason.Fragment{} = data) do
     data
   end

--- a/lib/logger_json/jason_safe_formatter.ex
+++ b/lib/logger_json/jason_safe_formatter.ex
@@ -1,0 +1,69 @@
+defmodule LoggerJSON.JasonSafeFormatter do
+  @moduledoc """
+  Produces metadata that is "safe" for calling Jason.encode!() on without errors.
+  This means that unexpected Logger metadata won't cause logging crashes.
+  Current formatting is...
+  - Maps: as is
+  - Printable binaries: as is
+  - Numbers: as is
+  - Structs that don't implement Jason.Encoder: converted to maps
+  - Tuples: converted to lists
+  - Keyword lists: converted to Maps
+  - everything else: inspected
+  """
+  def format(%Jason.Fragment{} = data) do
+    data
+  end
+
+  def format(%mod{} = data) do
+    if jason_implemented?(mod) do
+      data
+    else
+      data
+      |> Map.from_struct()
+      |> format()
+    end
+  end
+
+  def format(%{} = data) do
+    for {key, value} <- data, into: %{}, do: {key, format(value)}
+  end
+
+  def format([{key, _} | _] = data) when is_atom(key) do
+    Enum.into(data, %{}, fn
+      {key, value} -> {key, format(value)}
+    end)
+  rescue
+    _ -> for(d <- data, do: format(d))
+  end
+
+  def format({key, data}) when is_binary(key) or is_atom(key), do: %{key => format(data)}
+
+  def format(data) when is_tuple(data), do: Tuple.to_list(data)
+
+  def format(data) when is_number(data), do: data
+
+  def format(data) when is_binary(data) do
+    if String.valid?(data) && String.printable?(data) do
+      data
+    else
+      inspect(data)
+    end
+  end
+
+  def format(data) when is_list(data), do: for(d <- data, do: format(d))
+
+  def format(data) do
+    inspect(data, pretty: true, width: 80)
+  end
+
+  def jason_implemented?(mod) do
+    try do
+      :ok = Protocol.assert_impl!(Jason.Encoder, mod)
+      true
+    rescue
+      ArgumentError ->
+        false
+    end
+  end
+end

--- a/lib/logger_json/jason_safe_formatter.ex
+++ b/lib/logger_json/jason_safe_formatter.ex
@@ -25,8 +25,8 @@ defmodule LoggerJSON.JasonSafeFormatter do
   def format(false), do: false
   def format(data) when is_atom(data), do: data
 
-  def format(%mod{} = data) do
-    if jason_implemented?(mod) do
+  def format(%_struct{} = data) do
+    if jason_implemented?(data) do
       data
     else
       data
@@ -67,13 +67,8 @@ defmodule LoggerJSON.JasonSafeFormatter do
     inspect(data, pretty: true, width: 80)
   end
 
-  def jason_implemented?(mod) do
-    try do
-      :ok = Protocol.assert_impl!(Jason.Encoder, mod)
-      true
-    rescue
-      ArgumentError ->
-        false
-    end
+  def jason_implemented?(data) do
+    impl = Jason.Encoder.impl_for(data)
+    impl && impl != Jason.Encoder.Any
   end
 end

--- a/test/unit/json_safe_formatter_test.exs
+++ b/test/unit/json_safe_formatter_test.exs
@@ -6,6 +6,15 @@ defmodule LoggerJSON.JasonSafeFormatterTest do
   defmodule IDStruct, do: defstruct(id: nil)
 
   describe "format/1" do
+    test "allows nils" do
+      assert nil == Formatter.format(nil)
+    end
+
+    test "allows booleans" do
+      assert true == Formatter.format(true)
+      assert false == Formatter.format(false)
+    end
+
     test "allows strings" do
       assert "hello" == Formatter.format("hello")
     end

--- a/test/unit/json_safe_formatter_test.exs
+++ b/test/unit/json_safe_formatter_test.exs
@@ -15,8 +15,16 @@ defmodule LoggerJSON.JasonSafeFormatterTest do
       assert false == Formatter.format(false)
     end
 
-    test "allows strings" do
+    test "allows printable strings" do
       assert "hello" == Formatter.format("hello")
+    end
+
+    test "inspects non-printable binaries" do
+      assert "<<104, 101, 108, 108, 111, 0>>" == Formatter.format("hello" <> <<0>>)
+    end
+
+    test "allows atoms" do
+      assert :hello == Formatter.format(:hello)
     end
 
     test "allows numbers" do

--- a/test/unit/json_safe_formatter_test.exs
+++ b/test/unit/json_safe_formatter_test.exs
@@ -1,0 +1,59 @@
+defmodule LoggerJSON.JasonSafeFormatterTest do
+  use Logger.Case, async: true
+
+  alias LoggerJSON.JasonSafeFormatter, as: Formatter
+
+  defmodule IDStruct, do: defstruct(id: nil)
+
+  describe "format/1" do
+    test "allows strings" do
+      assert "hello" == Formatter.format("hello")
+    end
+
+    test "allows numbers" do
+      assert 123 == Formatter.format(123)
+    end
+
+    test "strips Structs" do
+      assert %{id: "hello"} == Formatter.format(%IDStruct{id: "hello"})
+    end
+
+    test "converts tuples to lists" do
+      assert [1, 2, 3] == Formatter.format({1, 2, 3})
+    end
+
+    test "converts Keyword lists to maps" do
+      assert %{a: 1, b: 2} == Formatter.format(a: 1, b: 2)
+    end
+
+    test "inspects functions" do
+      assert "&LoggerJSON.JasonSafeFormatter.format/1" == Formatter.format(&Formatter.format/1)
+    end
+
+    test "inspects pids" do
+      assert inspect(self()) == Formatter.format(self())
+    end
+
+    test "doesn't choke on things that look like keyword lists but aren't" do
+      assert [%{a: 1}, [:b, 2, :c]] == Formatter.format([{:a, 1}, {:b, 2, :c}])
+    end
+
+    test "formats nested structures" do
+      input = %{
+        foo: [
+          foo_a: %{"x" => 1, "y" => %IDStruct{id: 1}},
+          foo_b: [foo_b_1: 1, foo_b_2: {"2a", "2b"}]
+        ],
+        self: self()
+      }
+
+      assert %{
+               foo: %{
+                 foo_a: %{"x" => 1, "y" => %{id: 1}},
+                 foo_b: %{foo_b_1: 1, foo_b_2: %{"2a" => "2b"}}
+               },
+               self: inspect(self())
+             } == Formatter.format(input)
+    end
+  end
+end

--- a/test/unit/logger_json_basic_test.exs
+++ b/test/unit/logger_json_basic_test.exs
@@ -3,6 +3,8 @@ defmodule LoggerJSONBasicTest do
   require Logger
   alias LoggerJSON.Formatters.BasicLogger
 
+  defmodule IDStruct, do: defstruct(id: nil)
+
   setup do
     :ok =
       Logger.configure_backend(
@@ -62,6 +64,19 @@ defmodule LoggerJSONBasicTest do
 
       assert %{"message" => "hello"} = log
       assert %{} == log["metadata"]
+    end
+
+    test "converts Struct metadata to maps" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+
+      Logger.metadata(id_struct: %IDStruct{id: "test"})
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"metadata" => %{"id_struct" => %{"id" => "test"}}} = log
     end
   end
 

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -4,6 +4,8 @@ defmodule LoggerJSONGoogleTest do
   require Logger
   alias LoggerJSON.Formatters.GoogleCloudLogger
 
+  defmodule IDStruct, do: defstruct(id: nil)
+
   setup do
     :ok =
       Logger.configure_backend(
@@ -15,6 +17,8 @@ defmodule LoggerJSONGoogleTest do
         on_init: :disabled,
         formatter: GoogleCloudLogger
       )
+
+    :ok = Logger.reset_metadata([])
   end
 
   describe "configure_log_level!/1" do
@@ -183,11 +187,26 @@ defmodule LoggerJSONGoogleTest do
 
     test "ignore otp's metadata unixtime" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
+
       log =
         fn -> Logger.debug("hello") end
         |> capture_log()
         |> Jason.decode!()
+
       assert not is_integer(log["time"])
+    end
+
+    test "converts Struct metadata to maps" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+
+      Logger.metadata(id_struct: %IDStruct{id: "test"})
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"id_struct" => %{"id" => "test"}} = log
     end
   end
 


### PR DESCRIPTION
This PR adds a new `JasonSafeFormatter` module which is able to recursively walk metadata and make coerce it into Jason.encode! safe. 

I can confirm that this fixes #40 as we have experienced this in production and a few other Logger crashes related to dodgy data ending up in metadata.

We have made some opinionated calls on how to format the data when not compatible but hopefully this is an improvement on the current situation.

The opinionated bits are likely...

- we coerce Structs to Maps if they implement Jason.Encoder
- we attempt to coerce Keyword lists into Maps
- we convert Tuples to lists
- we inspect functions rather than attempting to call them

Credit where credit is due, I used a few commits from [this coingaming fork](https://github.com/coingaming/logger_json) for some pointers when putting this together.