### PR TITLE
[enhancement] Support for providing a extra_attributes_fn to LoggerJSON Plug 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ It's [available on Hex](https://hex.pm/packages/logger_json), the package can be
   5. Optionally. Log requests and responses by replacing a `Plug.Logger` in your endpoint with a:
 
   ```ex
-  plug LoggerJSON.Plug
+  plug LoggerJSON.Plug, extra_attributes_fn: &MyModule.put_meta/1
   ```
 
   6. Optionally. Log Ecto queries via Plug:
@@ -176,6 +176,26 @@ config :logger_json, :backend,
 
 You can replace default Jason encoder with other module that supports `encode_to_iodata!/1` function and
 enconding fragments.
+
+## Extra Attributes
+
+Additional data can be logged alongside the request by specifying a function to call which returns a %Jason.Fragment{}.
+
+<https://hexdocs.pm/jason/Jason.Helpers.html#json_map/1>
+
+```ex
+  defmodule MyModule do
+    import Jason.Helpers, only: [json_map: 1]
+
+    def put_meta(conn) do
+      [
+        metadata: json_map(
+          x-request-id: get_req_header(conn, "x-request-id")
+        )
+      ]
+    end
+  end
+  ```
 
 ## Documentation
 

--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -41,7 +41,10 @@ if Code.ensure_loaded?(Plug) do
 
           nil ->
             nil
-            # Raise for anything else or set as nil?
+
+          anything_else ->
+            raise ArgumentError,
+          "Incorrect input for `extra_attributes_fn`, should be one of 'function', 'nil',  got: #{inspect(anything_else)}"
         end
 
       {level, metadata_formatter, client_version_header, extra_attributes_fn}

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -124,7 +124,7 @@ defmodule LoggerJSON.PlugTest do
            } = Jason.decode!(log)
   end
 
-  test "has extra attributes configured" do
+  test "has extra_attributes_fn configured" do
     request_id = Ecto.UUID.generate()
 
     conn =
@@ -158,9 +158,20 @@ defmodule LoggerJSON.PlugTest do
     assert Map.has_key?(log_map, "sample_key")
     assert Map.has_key?(log_map, "meta")
     assert Map.has_key?(log_map["meta"], "x_request_id")
+
     assert %{
-      "x_request_id" => request_id
-    } == log_map["meta"]
+             "x_request_id" => request_id
+           } == log_map["meta"]
+  end
+
+  test "invalid extra_attributes_fn configuration" do
+    assert %ArgumentError{message: _, __exception__: true} =
+             catch_error(
+               defmodule MyPlugWithInvalidExtraAttributes do
+                 use Plug.Builder
+                 plug(LoggerJSON.Plug, extra_attributes_fn: "")
+               end
+             )
   end
 
   defp call(conn) do


### PR DESCRIPTION
Support adding metadata to LoggerJSON Plug logs. A very good example of this is logging added by gateways`x-request-id`