### PR TITLE
Ignore metadata "time"

### DIFF
--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -46,7 +46,7 @@ defmodule LoggerJSON do
   """
   @behaviour :gen_event
 
-  @ignored_metadata_keys ~w[ansi_color initial_call crash_reason pid gl mfa report_cb]a
+  @ignored_metadata_keys ~w[ansi_color initial_call crash_reason pid gl mfa report_cb time]a
 
   defstruct metadata: nil,
             level: nil,

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -169,6 +169,15 @@ defmodule LoggerJSONGoogleTest do
 
       assert %{"message" => "hello"} = log
     end
+
+    test "ignore otp's metadata unixtime" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+      assert not is_integer(log["time"])
+    end
   end
 
   describe "on_init/1 callback" do


### PR DESCRIPTION
## Description

When use Elixir 1.10 and GoogleCloudLogging Formatter, logger_json's millseconds "time" value be overwritten by metadata microseconds "time".
According to the documentation, logger_json be expected "time" value is milliseconds.
So, Made a change to add "time" to ignored_metadata_keys.

Fixed: #49

## Before

### Basic Formatter

```
%{"message" => "hello", "metadata" => %{"domain" => ["elixir"], "dynamic_metadata" => 5, "time" => 1596772387300756, "user_id" => 11}, "severity" => "debug", "time" => "2020-08-07T12:53:07.302Z"}
```

### GoogleCloudLogging Formatter

```
%{"domain" => ["elixir"], "logging.googleapis.com/sourceLocation" => %{"file" => "/Users/w1mvy/ghq/github.com/Nebo15/logger_json/test/unit/logger_
json_google_test.exs", "function" => "Elixir.LoggerJSONGoogleTest.test logs binary messages/1", "line" => 59}, "message" => "hello", "severity" => "DEBUG", "time" => 1596772397130034}
```

## After

### Basic Formatter

```
%{"message" => "hello", "metadata" => %{"domain" => ["elixir"], "dynamic_metadata" => 5, "user_id" => 11}, "severity" => "debug", "time" => "2020-08-07T12:54:31.489Z"}
```

### GoogleCloudLogging Formatter

```
%{"domain" => ["elixir"], "logging.googleapis.com/sourceLocation" => %{"file" => "/Users/w1mvy/ghq/github.com/Nebo15/logger_json/test/unit/logger_json_google_test.exs", "function" => "Elixir.LoggerJSONGoogleTest.test logs binary messages/1", "line" => 59}, "message" => "hello", "severity" => "DEBUG", "time" => "2020-08-07T12:54:43.897Z"}
```
