### PR TITLE
Add a DataDog formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 JSON console back-end for Elixir Logger.
 
 It can be used as drop-in replacement for default `:console` Logger back-end in cases where you use
-use Google Cloud Logger or other JSON-based log collectors.
+use Google Cloud Logger, DataDog Logger or other JSON-based log collectors.
 
 Minimum supported Erlang/OTP version is 20.
 
@@ -21,7 +21,7 @@ After adding this back-end you may also be interested in [redirecting otp and sa
 
 ## Log Format
 
-LoggerJSON provides two JSON formatters out of the box (see below for implementing your own custom formatter).
+LoggerJSON provides three JSON formatters out of the box (see below for implementing your own custom formatter).
 
 The `LoggerJSON.Formatters.BasicLogger` formatter provides a generic JSON formatted message with no vendor specific entries in the payload. A sample log entry from `LoggerJSON.Formatters.BasicLogger` looks like the following:
 
@@ -36,7 +36,7 @@ The `LoggerJSON.Formatters.BasicLogger` formatter provides a generic JSON format
 }
 ```
 
-The other formatter that comes with LoggerJSON is `LoggerJSON.Formatters.GoogleCloudLogger` and generates JSON that is compatible with the
+Another formatter that comes with LoggerJSON is `LoggerJSON.Formatters.GoogleCloudLogger` and generates JSON that is compatible with the
 [Google Cloud Logger LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) format:
 
   ```json

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -3,15 +3,15 @@ defmodule LoggerJSON do
   JSON console back-end for Elixir Logger.
 
   It can be used as drop-in replacement for default `:console` Logger back-end in cases where you use
-  use Google Cloud Logger or other JSON-based log collectors.
+  use Google Cloud Logger, DataDog Logger or other JSON-based log collectors.
 
   ## Log Format
 
-  LoggerJSON provides two JSON formatters out of the box.
+  LoggerJSON provides three JSON formatters out of the box.
 
   You can change this structure by implementing `LoggerJSON.Formatter` behaviour and passing module
-  name to `:formatter` config option. Example implementations can be found in `LoggerJSON.Formatters.GoogleCloudLogger`
-  and `LoggerJSON.Formatters.BasicLogger`.
+  name to `:formatter` config option. Example implementations can be found in `LoggerJSON.Formatters.GoogleCloudLogger`,
+  `LoggerJSON.Formatters.DataDogLogger` and `LoggerJSON.Formatters.BasicLogger`.
 
     ```elixir
     config :logger_json, :backend,

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -1,0 +1,82 @@
+defmodule LoggerJSON.Formatters.DataDogLogger do
+  @moduledoc """
+  DataDog Logger formatter
+
+  See: https://docs.datadoghq.com/logs/log_collection/?tab=http#send-your-application-logs-in-json
+  """
+  import Jason.Helpers, only: [json_map: 1]
+  alias LoggerJSON.{FormatterUtils, JasonSafeFormatter}
+
+  @behaviour LoggerJSON.Formatter
+
+  @processed_metadata_keys ~w[function application]a
+
+  def format_event(level, msg, timestamp, metadata, metadata_keys) do
+    Map.merge(
+      %{
+        timestamp: format_timestamp(timestamp),
+        status: level,
+        message: IO.iodata_to_binary(msg)
+      },
+      format_metadata(metadata, metadata_keys)
+    )
+  rescue
+    _ -> "could not format: #{inspect({level, msg, metadata})}"
+  end
+
+  defp format_metadata(metadata, metadata_keys) do
+    metadata
+    |> LoggerJSON.take_metadata(metadata_keys, @processed_metadata_keys)
+    |> JasonSafeFormatter.format()
+    |> FormatterUtils.maybe_put(:error, format_process_crash(metadata))
+  end
+
+  defp format_process_crash(metadata) do
+    if crash_reason = Keyword.get(metadata, :crash_reason) do
+      initial_call = Keyword.get(metadata, :initial_call)
+
+      case format_crash_reason(crash_reason) do
+        {kind, message, stacktrace} ->
+          json_map(
+            initial_call: format_initial_call(initial_call),
+            stack: stacktrace,
+            message: message,
+            kind: kind
+          )
+
+        message ->
+          json_map(
+            initial_call: format_initial_call(initial_call),
+            message: message
+          )
+      end
+    end
+  end
+
+  defp format_initial_call(nil), do: nil
+
+  defp format_initial_call({module, function, arity}) do
+    Exception.format_mfa(module, function, arity)
+  end
+
+  defp format_crash_reason({kind, reason}) when kind in [:throw, :nocatch] do
+    {:throw, Exception.format(:throw, reason), nil}
+  end
+
+  defp format_crash_reason({:exit, reason}) do
+    {:exit, Exception.format(:exit, reason), nil}
+  end
+
+  defp format_crash_reason({%kind{} = exception, stacktrace}) do
+    {kind, Exception.format_banner(:error, exception), Exception.format_stacktrace(stacktrace)}
+  end
+
+  defp format_crash_reason(other) do
+    inspect(other)
+  end
+
+  defp format_timestamp({{year, month, day}, {hour, min, sec, ms}}) do
+    {:ok, datetime} = NaiveDateTime.new(year, month, day, hour, min, sec, {ms * 1000, 3})
+    NaiveDateTime.to_iso8601(datetime)
+  end
+end


### PR DESCRIPTION
Adds a logger formatter for DataDog. We have been using this formatter in production for the last several months.

The readme can probably use an example of the output payload. Let me know if you would like me to add, and anything else that I had missed.