### PR TITLE
add datadog formatters

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -1,6 +1,7 @@
 defmodule LoggerJSON.Formatters.DatadogLogger do
   @moduledoc """
-  DataDog formatter.
+  DataDog formatter. Adhears to the DataDog
+  [default standard attribute list](https://docs.datadoghq.com/logs/processing/attributes_naming_convention/#default-standard-attribute-list).
   """
   import Jason.Helpers, only: [json_map: 1]
 
@@ -51,6 +52,6 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
 
   defp node_hostname do
     {:ok, hostname} = :inet.gethostname()
-    hostname
+    to_string(hostname)
   end
 end

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -1,0 +1,56 @@
+defmodule LoggerJSON.Formatters.DatadogLogger do
+  @moduledoc """
+  DataDog formatter.
+  """
+  import Jason.Helpers, only: [json_map: 1]
+
+  alias LoggerJSON.{FormatterUtils, JasonSafeFormatter}
+
+  @behaviour LoggerJSON.Formatter
+
+  @processed_metadata_keys ~w[pid file line function module application]a
+
+  def format_event(level, msg, ts, md, md_keys) do
+    Map.merge(
+      %{
+        logger: json_map(
+          thread_name: inspect(Keyword.get(md, :pid)),
+          method_name: method_name(md)
+        ),
+        message: IO.chardata_to_string(msg),
+        syslog: json_map(
+          hostname: node_hostname(),
+          severity: Atom.to_string(level),
+          timestamp: FormatterUtils.format_timestamp(ts)
+        )
+      },
+      format_metadata(md, md_keys)
+    )
+  end
+
+  defp format_metadata(md, md_keys) do
+    LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys)
+    |> JasonSafeFormatter.format()
+    |> FormatterUtils.maybe_put(:error, format_error(md))
+  end
+
+  defp format_error(md) do
+    with %{reason: reason} <- FormatterUtils.format_process_crash(md) do
+      json_map(
+        stack: reason
+      )
+    end
+  end
+
+  defp method_name(metadata) do
+    function = Keyword.get(metadata, :function)
+    module = Keyword.get(metadata, :module)
+
+    FormatterUtils.format_function(module, function)
+  end
+
+  defp node_hostname do
+    {:ok, hostname} = :inet.gethostname()
+    hostname
+  end
+end

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -3,7 +3,7 @@ if Code.ensure_loaded?(Plug) do
     @moduledoc """
     This formatter builds a metadata which is natively supported by Datadog:
 
-      * `http` - see [LogEntry#HttpRequest](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest);
+      * `http` - see [DataDog](https://docs.datadoghq.com/logs/processing/attributes_naming_convention/#http-requests);
       * `phoenix.controller` - Phoenix controller that processed the request;
       * `phoenix.action` - Phoenix action that processed the request;
     """

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -1,0 +1,75 @@
+if Code.ensure_loaded?(Plug) do
+  defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLogger do
+    @moduledoc """
+    This formatter builds a metadata which is natively supported by Datadog:
+
+      * `http` - see [LogEntry#HttpRequest](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest);
+      * `phoenix.controller` - Phoenix controller that processed the request;
+      * `phoenix.action` - Phoenix action that processed the request;
+    """
+    import Jason.Helpers, only: [json_map: 1]
+
+    @doc false
+    def build_metadata(conn, latency, client_version_header) do
+      client_metadata(conn, client_version_header) ++
+      phoenix_metadata(conn) ++
+      [
+        duration: native_to_nanoseconds(latency),
+        http:
+          json_map(
+            url: request_url(conn),
+            status_code: conn.status,
+            method: conn.method,
+            referer: LoggerJSON.Plug.get_header(conn, "referer"),
+            request_id: Keyword.get(Logger.metadata(), :request_id),
+            useragent: LoggerJSON.Plug.get_header(conn, "user-agent"),
+            url_details: json_map(
+              host: conn.host,
+              port: conn.port,
+              path: conn.request_path,
+              queryString: conn.query_string,
+              scheme: conn.scheme
+            )
+          ),
+        network:
+          json_map(
+            client:
+              json_map(
+                ip: remote_ip(conn)
+              )
+          )
+      ]
+    end
+
+    defp native_to_nanoseconds(nil) do
+      nil
+    end
+
+    defp native_to_nanoseconds(native) do
+      System.convert_time_unit(native, :native, :nanosecond)
+    end
+
+    defp request_url(%{request_path: "/"} = conn), do: "#{conn.scheme}://#{conn.host}/"
+    defp request_url(conn), do: "#{conn.scheme}://#{Path.join(conn.host, conn.request_path)}"
+
+    defp remote_ip(conn) do
+      LoggerJSON.Plug.get_header(conn, "x-forwarded-for") || to_string(:inet_parse.ntoa(conn.remote_ip))
+    end
+
+    defp client_metadata(conn, client_version_header) do
+      if api_version = LoggerJSON.Plug.get_header(conn, client_version_header) do
+        [client: json_map(api_version: api_version)]
+      else
+        []
+      end
+    end
+
+    defp phoenix_metadata(%{private: %{phoenix_controller: controller, phoenix_action: action}}) do
+      [phoenix: json_map(controller: controller, action: action)]
+    end
+
+    defp phoenix_metadata(_conn) do
+      []
+    end
+  end
+end

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -1,0 +1,318 @@
+defmodule LoggerJSONDatadogTest do
+  use Logger.Case, async: false
+  import ExUnit.CaptureIO
+  require Logger
+  alias LoggerJSON.Formatters.DatadogLogger
+
+  defmodule IDStruct, do: defstruct(id: nil)
+
+  setup do
+    :ok =
+      Logger.configure_backend(
+        LoggerJSON,
+        device: :user,
+        level: nil,
+        metadata: [],
+        json_encoder: Jason,
+        on_init: :disabled,
+        formatter: DatadogLogger
+      )
+
+    :ok = Logger.reset_metadata([])
+  end
+
+  describe "configure_log_level!/1" do
+    test "tolerates nil values" do
+      assert :ok == LoggerJSON.configure_log_level!(nil)
+    end
+
+    test "raises on invalid LOG_LEVEL" do
+      assert_raise ArgumentError, fn ->
+        LoggerJSON.configure_log_level!("super_critical")
+      end
+
+      assert_raise ArgumentError, fn ->
+        LoggerJSON.configure_log_level!(1_337)
+      end
+    end
+
+    test "configures log level with valid string value" do
+      :ok = LoggerJSON.configure_log_level!("debug")
+    end
+
+    test "configures log level with valid atom value" do
+      :ok = LoggerJSON.configure_log_level!(:debug)
+    end
+  end
+
+  test "logs empty binary messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug("") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => ""} = log
+  end
+
+  test "logs binary messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "hello"} = log
+  end
+
+  test "logs empty iodata messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => ""} = log
+  end
+
+  test "logs iodata messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([?h, ?e, ?l, ?l, ?o]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "hello"} = log
+  end
+
+  test "logs chardata messages" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([?π, ?α, ?β]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "παβ"} = log
+  end
+
+  test "log message does not break escaping" do
+    Logger.configure_backend(LoggerJSON, metadata: :all)
+
+    log =
+      fn -> Logger.debug([?", ?h]) end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "\"h"} = log
+
+    log =
+      fn -> Logger.debug("\"h") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"message" => "\"h"} = log
+  end
+
+  test "does not start when there is no user" do
+    :ok = Logger.remove_backend(LoggerJSON)
+    user = Process.whereis(:user)
+
+    try do
+      Process.unregister(:user)
+      assert {:error, :ignore} == :gen_event.add_handler(Logger, LoggerJSON, LoggerJSON)
+    after
+      Process.register(user, :user)
+    end
+  after
+    {:ok, _} = Logger.add_backend(LoggerJSON)
+  end
+
+  test "may use another device" do
+    Logger.configure_backend(LoggerJSON, device: :standard_error)
+
+    assert capture_io(:standard_error, fn ->
+             Logger.debug("hello")
+             Logger.flush()
+           end) =~ "hello"
+  end
+
+  describe "metadata" do
+    test "can be configured" do
+      Logger.configure_backend(LoggerJSON, metadata: [:user_id])
+
+      assert capture_log(fn ->
+               Logger.debug("hello")
+             end) =~ "hello"
+
+      Logger.metadata(user_id: 13)
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"user_id" => 13} = log
+    end
+
+    test "can be configured to :all" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+
+      Logger.metadata(user_id: 11)
+      Logger.metadata(dynamic_metadata: 5)
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"user_id" => 11} = log
+      assert %{"dynamic_metadata" => 5} = log
+    end
+
+    test "can be empty" do
+      Logger.configure_backend(LoggerJSON, metadata: [])
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"message" => "hello"} = log
+    end
+
+    test "ignore otp's metadata unixtime" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert not is_integer(log["time"])
+    end
+
+    test "converts Struct metadata to maps" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+
+      Logger.metadata(id_struct: %IDStruct{id: "test"})
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"id_struct" => %{"id" => "test"}} = log
+    end
+  end
+
+  describe "on_init/1 callback" do
+    test "raises when invalid" do
+      assert_raise ArgumentError,
+                   "invalid :on_init option for :logger_json application. " <>
+                     "Expected a tuple with module, function and args, got: :atom",
+                   fn ->
+                     LoggerJSON.init({LoggerJSON, [on_init: :atom]})
+                   end
+    end
+
+    test "is triggered" do
+      Logger.configure_backend(LoggerJSON, metadata: [], on_init: {LoggerJSONDatadogTest, :on_init_cb, []})
+
+      Logger.metadata(user_id: 11)
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"user_id" => 11} = log
+    end
+  end
+
+  test "contains source location" do
+    %{module: mod, function: {name, arity}, file: file, line: line} = __ENV__
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    line = line + 3
+    function = "Elixir.#{inspect(mod)}.#{name}/#{arity}"
+
+    assert %{
+             "logger" => %{
+               "method_name" => ^function
+             }
+           } = log
+  end
+
+  test "may configure level" do
+    Logger.configure_backend(LoggerJSON, level: :info)
+
+    assert capture_log(fn ->
+             Logger.debug("hello")
+           end) == ""
+  end
+
+  test "logs severity" do
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"syslog" => %{"severity" => "debug"}} = log
+
+    log =
+      fn -> Logger.warn("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert %{"syslog" => %{"severity" => "warn"}} = log
+  end
+
+  test "logs crash reason when present" do
+    Logger.configure_backend(LoggerJSON, metadata: [:crash_reason])
+    Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []})
+
+    log =
+      capture_log(fn -> Logger.debug("hello") end)
+      |> Jason.decode!()
+
+    assert is_nil(log["error"]["initial_call"])
+    assert log["error"]["reason"] == "** (RuntimeError) oops"
+  end
+
+  test "logs erlang style crash reasons" do
+    Logger.configure_backend(LoggerJSON, metadata: [:crash_reason])
+    Logger.metadata(crash_reason: {:socket_closed_unexpectedly, []})
+
+    log =
+      capture_log(fn -> Logger.debug("hello") end)
+      |> Jason.decode!()
+
+    assert is_nil(log["error"]["initial_call"])
+    assert log["error"]["reason"] == "{:socket_closed_unexpectedly, []}"
+  end
+
+  test "logs initial call when present" do
+    Logger.configure_backend(LoggerJSON, metadata: [:initial_call])
+    Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []}, initial_call: {Foo, :bar, 3})
+
+    log =
+      capture_log(fn -> Logger.debug("hello") end)
+      |> Jason.decode!()
+
+    assert log["error"]["initial_call"] == "Elixir.Foo.bar/3"
+  end
+
+  # Sets metadata to :all for test purposes
+  def on_init_cb(conf) do
+    {:ok, Keyword.put(conf, :metadata, :all)}
+  end
+end


### PR DESCRIPTION
This adds a `DatadogLogger` and a `Plug` `DatadogLogger`. Copied mostly from the Google version. Field names are from the [Datadog docs](https://docs.datadoghq.com/logs/processing/attributes_naming_convention/#default-standard-attribute-list) and should work out of the box for most people.

Let me know if there are things I missed, or anything you want changed.

Outputs:
```json
{
  "domain": ["elixir"],
  "logger": {
    "thread_name": "#PID<0.510.0>",
    "method_name": "Elixir.Appsignal.initialize/0"
  },
  "message": "AppSignal disabled.",
  "syslog": {
    "hostname": [10, 10, 100, 100, 100, 100, 100],
    "severity": "info",
    "timestamp": "2020-12-14T19:15:28.207Z"
  }
}
```

```json
{
  "domain": ["elixir"],
  "logger": {
    "thread_name": "#PID<0.712.0>",
    "method_name": "Elixir.LoggerJSON.Ecto.telemetry_logging_handler/4"
  },
  "message": "CREATE TABLE IF NOT EXISTS `schema_migrations` (`version` bigint, `inserted_at` datetime, PRIMARY KEY (`version`)) ENGINE = INNODB",
  "query": {
    "decode_time_μs": 1,
    "execution_time_μs": 164,
    "latency_μs": 475,
    "queue_time_μs": 309,
    "repo": "Recognizer.Repo"
  },
  "syslog": {
    "hostname": [10, 10, 100, 100, 100, 100, 100],
    "severity": "debug",
    "timestamp": "2020-12-14T19:16:47.782Z"
  }
}
```

```json
{
  "domain": ["elixir"],
  "duration": 3863403,
  "http": {
    "url": "http://localhost/create-account",
    "status_code": 200,
    "method": "GET",
    "referer": "http://localhost:4000/login",
    "request_id": "http_FlDCOItxeudZJ20AAADD",
    "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36",
    "url_details": {
      "host": "localhost",
      "port": 4000,
      "path": "/create-account",
      "queryString": "",
      "scheme": "http"
    }
  },
  "logger": {
    "thread_name": "#PID<0.1042.0>",
    "method_name": "Elixir.LoggerJSON.Plug.call/2"
  },
  "message": "",
  "network": {
    "client": {
      "ip": "127.0.0.1"
    }
  },
  "phoenix": {
    "controller": "Elixir.RecognizerWeb.Accounts.UserRegistrationController",
    "action": "new"
  },
  "request_id": "http_FlDCOItxeudZJ20AAADD",
  "syslog": {
    "hostname": [10, 10, 100, 100, 100, 100, 100],
    "severity": "info",
    "timestamp": "2020-12-14T19:16:55.088Z"
  }
}
```