### PR TITLE
fix x-forwarded-for returning a list of ip addresses

### DIFF
--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -45,13 +45,5 @@ if Code.ensure_loaded?(Plug) do
         conn
       end)
     end
-
-    @doc false
-    def get_header(conn, header) do
-      case Conn.get_req_header(conn, header) do
-        [] -> nil
-        [val | _] -> val
-      end
-    end
   end
 end

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -20,9 +20,9 @@ if Code.ensure_loaded?(Plug) do
               url: request_url(conn),
               status_code: conn.status,
               method: conn.method,
-              referer: LoggerJSON.Plug.get_header(conn, "referer"),
+              referer: LoggerJSON.PlugUtils.get_header(conn, "referer"),
               request_id: Keyword.get(Logger.metadata(), :request_id),
-              useragent: LoggerJSON.Plug.get_header(conn, "user-agent"),
+              useragent: LoggerJSON.PlugUtils.get_header(conn, "user-agent"),
               url_details:
                 json_map(
                   host: conn.host,
@@ -32,7 +32,7 @@ if Code.ensure_loaded?(Plug) do
                   scheme: conn.scheme
                 )
             ),
-          network: json_map(client: json_map(ip: remote_ip(conn)))
+          network: json_map(client: json_map(ip: LoggerJSON.PlugUtils.remote_ip(conn)))
         ]
     end
 
@@ -47,12 +47,8 @@ if Code.ensure_loaded?(Plug) do
     defp request_url(%{request_path: "/"} = conn), do: "#{conn.scheme}://#{conn.host}/"
     defp request_url(conn), do: "#{conn.scheme}://#{Path.join(conn.host, conn.request_path)}"
 
-    defp remote_ip(conn) do
-      LoggerJSON.Plug.get_header(conn, "x-forwarded-for") || to_string(:inet_parse.ntoa(conn.remote_ip))
-    end
-
     defp client_metadata(conn, client_version_header) do
-      if api_version = LoggerJSON.Plug.get_header(conn, client_version_header) do
+      if api_version = LoggerJSON.PlugUtils.get_header(conn, client_version_header) do
         [client: json_map(api_version: api_version)]
       else
         []

--- a/lib/logger_json/plug/metadata_formatters/elk.ex
+++ b/lib/logger_json/plug/metadata_formatters/elk.ex
@@ -21,9 +21,9 @@ if Code.ensure_loaded?(Plug) do
     @doc false
     def build_metadata(conn, latency, client_version_header) do
       latency_μs = System.convert_time_unit(latency, :native, :microsecond)
-      user_agent = LoggerJSON.Plug.get_header(conn, "user-agent")
-      ip = remote_ip(conn)
-      api_version = LoggerJSON.Plug.get_header(conn, client_version_header)
+      user_agent = LoggerJSON.PlugUtils.get_header(conn, "user-agent")
+      ip = LoggerJSON.PlugUtils.remote_ip(conn)
+      api_version = LoggerJSON.PlugUtils.get_header(conn, client_version_header)
       {hostname, vm_pid} = node_metadata()
 
       phoenix_metadata(conn) ++
@@ -48,10 +48,6 @@ if Code.ensure_loaded?(Plug) do
 
     defp connection_type(%{state: :set_chunked}), do: "chunked"
     defp connection_type(_), do: "sent"
-
-    defp remote_ip(conn) do
-      LoggerJSON.Plug.get_header(conn, "x-forwarded-for") || to_string(:inet_parse.ntoa(conn.remote_ip))
-    end
 
     defp phoenix_metadata(%{private: %{phoenix_controller: controller, phoenix_action: action}}) do
       [phoenix: %{controller: controller, action: action}]

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -21,9 +21,9 @@ if Code.ensure_loaded?(Plug) do
       request_path = conn.request_path
       request_url = request_url(conn)
       status = conn.status
-      user_agent = LoggerJSON.Plug.get_header(conn, "user-agent")
-      remote_ip = remote_ip(conn)
-      referer = LoggerJSON.Plug.get_header(conn, "referer")
+      user_agent = LoggerJSON.PlugUtils.get_header(conn, "user-agent")
+      remote_ip = LoggerJSON.PlugUtils.remote_ip(conn)
+      referer = LoggerJSON.PlugUtils.get_header(conn, "referer")
       {hostname, vm_pid} = node_metadata()
 
       client_metadata(conn, client_version_header) ++
@@ -56,12 +56,8 @@ if Code.ensure_loaded?(Plug) do
     defp request_url(%{request_path: "/"} = conn), do: "#{conn.scheme}://#{conn.host}/"
     defp request_url(conn), do: "#{conn.scheme}://#{Path.join(conn.host, conn.request_path)}"
 
-    defp remote_ip(conn) do
-      LoggerJSON.Plug.get_header(conn, "x-forwarded-for") || to_string(:inet_parse.ntoa(conn.remote_ip))
-    end
-
     defp client_metadata(conn, client_version_header) do
-      if api_version = LoggerJSON.Plug.get_header(conn, client_version_header) do
+      if api_version = LoggerJSON.PlugUtils.get_header(conn, client_version_header) do
         [client: json_map(api_version: api_version)]
       else
         []

--- a/lib/logger_json/plug_utils.ex
+++ b/lib/logger_json/plug_utils.ex
@@ -1,0 +1,35 @@
+if Code.ensure_loaded?(Plug) do
+  defmodule LoggerJSON.PlugUtils do
+    @moduledoc """
+    This module contains functions that can be used across different
+    `LoggerJSON.Plug.MetadataFormatters` implementations to provide
+    common functionality.
+    """
+
+    alias Plug.Conn
+
+    @doc """
+    Grabs the client IP address from `Plug.Conn`. First we try
+    to grab the client IP from the `x-forwarded-for` header.
+    Then we fall back to the `conn.remote_ip` field.
+    """
+    def remote_ip(conn) do
+      if header_value = get_header(conn, "x-forwarded-for") do
+        header_value
+        |> String.split(",")
+        |> hd()
+        |> String.trim()
+      else
+        to_string(:inet_parse.ntoa(conn.remote_ip))
+      end
+    end
+
+    @doc false
+    def get_header(conn, header) do
+      case Conn.get_req_header(conn, header) do
+        [] -> nil
+        [val | _] -> val
+      end
+    end
+  end
+end


### PR DESCRIPTION
I created a `LoggerJSON.PlugUtils` module to match the `LoggerJSON.FormatterUtils` module. I then moved the `get_header/2` function into it, and moved the common (same in all plug formatters) `remote_ip/1` function in it as well.

I updated the `remote_ip/1` function to only return the client IP address if it was sent through a proxy. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) and our System76 logs, this header can return a list of IP addresses. Datadog and Google Cloud Logger both document this field as a simple string, not a list of them.

Let me know if this module change is too much and I can undo it. As well as any changes you need. 🎊 