### PR TITLE
Change System.get_pid/0 to System.pid/0

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/elk.ex
+++ b/lib/logger_json/plug/metadata_formatters/elk.ex
@@ -61,7 +61,7 @@ if Code.ensure_loaded?(Plug) do
       {:ok, hostname} = :inet.gethostname()
 
       vm_pid =
-        case Integer.parse(System.get_pid()) do
+        case Integer.parse(System.pid()) do
           {pid, _units} -> pid
           _ -> nil
         end

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(Plug) do
       {:ok, hostname} = :inet.gethostname()
 
       vm_pid =
-        case Integer.parse(System.get_pid()) do
+        case Integer.parse(System.pid()) do
           {pid, _units} -> pid
           _ -> nil
         end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule LoggerJSON.Mixfile do
     [
       app: :logger_json,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [] ++ Mix.compilers(),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
`System.get_pid/0` is deprecated in flavor of `System.pid/0`. Since we
use this function, we need to bump minimum elixir requirement to be
at least version 1.9.