### PR TITLE
Prefix span_id and trace_id keys with "dd." to connect logs and traces

### DIFF
--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -208,6 +208,20 @@ defmodule LoggerJSONDatadogTest do
 
       assert %{"id_struct" => %{"id" => "test"}} = log
     end
+
+    test "convert trace_id/span_id to expected datadog keys" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      Logger.metadata(trace_id: "1", span_id: "2")
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"dd.trace_id" => "1", "dd.span_id" => "2"} = log
+      assert Map.has_key?(log, "trace_id") == false
+      assert Map.has_key?(log, "span_id") == false
+    end
   end
 
   describe "on_init/1 callback" do


### PR DESCRIPTION
Otherwise datadog is unable to link a log entry to the corresponding trace. See https://docs.datadoghq.com/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=jsonlogs : "ensure the name of the logs attribute that contains the trace id is dd.trace_id"