### PR TITLE
Add filename and line number in DatadogLogger formatter

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -19,7 +19,9 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
         logger:
           json_map(
             thread_name: inspect(Keyword.get(md, :pid)),
-            method_name: method_name(md)
+            method_name: method_name(md),
+            file_name: Keyword.get(md, :file),
+            line: Keyword.get(md, :line)
           ),
         message: IO.chardata_to_string(msg),
         syslog:

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -249,20 +249,27 @@ defmodule LoggerJSONDatadogTest do
   end
 
   test "contains source location" do
-    %{module: mod, function: {name, arity}, file: _file, line: _line} = __ENV__
+    %{module: mod, function: {name, arity}, file: file, line: before_log_line_num} = __ENV__
 
     log =
       fn -> Logger.debug("hello") end
       |> capture_log()
       |> Jason.decode!()
 
+    %{line: after_log_line_num} = __ENV__
+
     function = "Elixir.#{inspect(mod)}.#{name}/#{arity}"
 
     assert %{
              "logger" => %{
-               "method_name" => ^function
+               "method_name" => ^function,
+               "line" => log_line_num,
+               "file_name" => ^file,
+               "thread_name" => _
              }
            } = log
+
+    assert log_line_num > before_log_line_num and log_line_num < after_log_line_num
   end
 
   test "may configure level" do


### PR DESCRIPTION
`file_name` and `line` are not reserved keywords for `logger` entry. But I think it's the best place to put this information.