### PR TITLE
feat: allow setting Datadog syslog.hostname attribute

### DIFF
--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -62,7 +62,7 @@ defmodule LoggerJSON do
             json_encoder: nil,
             on_init: nil,
             formatter: nil,
-            formatter_state: []
+            formatter_state: %{}
 
   @doc """
   Configures Logger log level at runtime by using value from environment variable.
@@ -204,7 +204,7 @@ defmodule LoggerJSON do
       |> Keyword.get(:metadata, [])
       |> configure_metadata()
 
-    formatter_opts = Keyword.get(config, :formatter_opts, [])
+    formatter_opts = Keyword.get(config, :formatter_opts, %{})
     formatter_state = apply(formatter, :init, [formatter_opts])
 
     %{

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -7,14 +7,20 @@ defmodule LoggerJSON do
 
   ## Log Format
 
-  LoggerJSON provides two JSON formatters out of the box.
+  LoggerJSON provides three JSON formatters out of the box.
 
   You can change this structure by implementing `LoggerJSON.Formatter` behaviour and passing module
-  name to `:formatter` config option. Example implementations can be found in `LoggerJSON.Formatters.GoogleCloudLogger`
-  and `LoggerJSON.Formatters.BasicLogger`.
+  name to `:formatter` config option. Example implementations can be found in `LoggerJSON.Formatters.GoogleCloudLogger`,
+  `LoggerJSON.Formatters.DatadogLogger`, and `LoggerJSON.Formatters.BasicLogger`.
 
       config :logger_json, :backend,
         formatter: MyFormatterImplementation
+
+  If your formatter supports different options, you can specify them with `:formatter_opts`.
+
+      config :logger_json, :backend,
+        formatter: LoggerJSON.Formatters.DatadogLogger,
+        formatter_opts: [hostname: "example.com"]
 
   ## Encoders support
 

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -7,6 +7,13 @@ defmodule LoggerJSON.Formatter do
   """
 
   @doc """
+  Initialization callback. Ran on startup with the given `formatter_opts` list.
+
+  Returned list will be used as formatter_state in `format_event/6`.
+  """
+  @callback init(Keyword.t()) :: Keyword.t()
+
+  @doc """
   Format event callback.
 
   Returned map will be encoded to JSON.
@@ -16,6 +23,7 @@ defmodule LoggerJSON.Formatter do
               msg :: Logger.message(),
               ts :: Logger.Formatter.time(),
               md :: [atom] | :all,
-              state :: map
+              state :: map,
+              formatter_state :: Keyword.t()
             ) :: map | iodata() | %Jason.Fragment{}
 end

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -24,6 +24,6 @@ defmodule LoggerJSON.Formatter do
               ts :: Logger.Formatter.time(),
               md :: [atom] | :all,
               state :: map,
-              formatter_state :: Keyword.t()
+              formatter_state :: map
             ) :: map | iodata() | %Jason.Fragment{}
 end

--- a/lib/logger_json/formatters/basic_logger.ex
+++ b/lib/logger_json/formatters/basic_logger.ex
@@ -12,7 +12,10 @@ defmodule LoggerJSON.Formatters.BasicLogger do
   @processed_metadata_keys ~w[pid file line function module application]a
 
   @impl true
-  def format_event(level, msg, ts, md, md_keys) do
+  def init(_formatter_opts), do: []
+
+  @impl true
+  def format_event(level, msg, ts, md, md_keys, _formatter_state) do
     json_map(
       time: FormatterUtils.format_timestamp(ts),
       severity: Atom.to_string(level),

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -13,7 +13,11 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
 
   @processed_metadata_keys ~w[pid file line function module application span_id trace_id]a
 
-  def format_event(level, msg, ts, md, md_keys) do
+  @impl true
+  def init(_formatter_opts), do: []
+
+  @impl true
+  def format_event(level, msg, ts, md, md_keys, _formatter_state) do
     Map.merge(
       %{
         logger:

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -28,17 +28,17 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
 
   @behaviour LoggerJSON.Formatter
 
-  @default_opts [hostname: :system]
+  @default_opts %{hostname: :system}
   @processed_metadata_keys ~w[pid file line function module application span_id trace_id]a
 
   @impl true
-  def init(formatter_opts \\ []) do
-    opts = Keyword.merge(@default_opts, formatter_opts)
+  def init(formatter_opts \\ %{}) do
+    opts = Map.merge(@default_opts, formatter_opts)
 
-    unless is_binary(opts[:hostname]) or opts[:hostname] in [:system, :unset] do
+    unless is_binary(opts.hostname) or opts.hostname in [:system, :unset] do
       raise ArgumentError,
             "invalid :hostname option for :formatter_opts logger_json backend. " <>
-              "Expected :system, :unset, or string, " <> "got: #{inspect(opts[:hostname])}"
+              "Expected :system, :unset, or string, " <> "got: #{inspect(opts.hostname)}"
     end
 
     opts
@@ -56,7 +56,7 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
             line: Keyword.get(md, :line)
           ),
         message: IO.chardata_to_string(msg),
-        syslog: syslog(level, ts, formatter_state[:hostname])
+        syslog: syslog(level, ts, formatter_state.hostname)
       },
       format_metadata(md, md_keys)
     )

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -26,7 +26,6 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
         message: IO.chardata_to_string(msg),
         syslog:
           json_map(
-            hostname: node_hostname(),
             severity: Atom.to_string(level),
             timestamp: FormatterUtils.format_timestamp(ts)
           )
@@ -60,10 +59,5 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
     module = Keyword.get(metadata, :module)
 
     FormatterUtils.format_function(module, function)
-  end
-
-  defp node_hostname do
-    {:ok, hostname} = :inet.gethostname()
-    to_string(hostname)
   end
 end

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -19,6 +19,9 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
     {:error, "ERROR"}
   ]
 
+  @impl true
+  def init(_formatter_opts), do: []
+
   @doc """
   Builds structured payload which is mapped to Google Cloud Logger
   [`LogEntry`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) format.
@@ -26,7 +29,8 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
   See: https://cloud.google.com/logging/docs/agent/configuration#special_fields_in_structured_payloads
   """
   for {level, gcp_level} <- @severity_levels do
-    def format_event(unquote(level), msg, ts, md, md_keys) do
+    @impl true
+    def format_event(unquote(level), msg, ts, md, md_keys, _formatter_state) do
       Map.merge(
         %{
           time: FormatterUtils.format_timestamp(ts),
@@ -38,7 +42,8 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
     end
   end
 
-  def format_event(_level, msg, ts, md, md_keys) do
+  @impl true
+  def format_event(_level, msg, ts, md, md_keys, _formatter_state) do
     Map.merge(
       %{
         time: FormatterUtils.format_timestamp(ts),

--- a/test/unit/logger_json/ecto_test.exs
+++ b/test/unit/logger_json/ecto_test.exs
@@ -13,7 +13,7 @@ defmodule LoggerJSON.EctoTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: LoggerJSON.Formatters.GoogleCloudLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
 
     diff = :erlang.convert_time_unit(1, :microsecond, :native)

--- a/test/unit/logger_json/ecto_test.exs
+++ b/test/unit/logger_json/ecto_test.exs
@@ -12,7 +12,8 @@ defmodule LoggerJSON.EctoTest do
         metadata: [],
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: LoggerJSON.Formatters.GoogleCloudLogger
+        formatter: LoggerJSON.Formatters.GoogleCloudLogger,
+        formatter_state: []
       )
 
     diff = :erlang.convert_time_unit(1, :microsecond, :native)

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -25,7 +25,7 @@ defmodule LoggerJSON.PlugTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: LoggerJSON.Formatters.GoogleCloudLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
   end
 

--- a/test/unit/logger_json/plug_test.exs
+++ b/test/unit/logger_json/plug_test.exs
@@ -24,7 +24,8 @@ defmodule LoggerJSON.PlugTest do
         metadata: :all,
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: LoggerJSON.Formatters.GoogleCloudLogger
+        formatter: LoggerJSON.Formatters.GoogleCloudLogger,
+        formatter_state: []
       )
   end
 

--- a/test/unit/logger_json_basic_test.exs
+++ b/test/unit/logger_json_basic_test.exs
@@ -14,7 +14,8 @@ defmodule LoggerJSONBasicTest do
         metadata: [],
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: BasicLogger
+        formatter: BasicLogger,
+        formatter_state: []
       )
   end
 

--- a/test/unit/logger_json_basic_test.exs
+++ b/test/unit/logger_json_basic_test.exs
@@ -15,7 +15,7 @@ defmodule LoggerJSONBasicTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: BasicLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
   end
 

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -16,7 +16,7 @@ defmodule LoggerJSONDatadogTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: DatadogLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
 
     :ok = Logger.reset_metadata([])
@@ -282,7 +282,7 @@ defmodule LoggerJSONDatadogTest do
   end
 
   test "logs hostname when set to :system" do
-    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: :system])
+    Logger.configure_backend(LoggerJSON, formatter_opts: %{hostname: :system})
     {:ok, hostname} = :inet.gethostname()
 
     log =
@@ -294,7 +294,7 @@ defmodule LoggerJSONDatadogTest do
   end
 
   test "does not log hostname when set to :unset" do
-    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: :unset])
+    Logger.configure_backend(LoggerJSON, formatter_opts: %{hostname: :unset})
 
     log =
       fn -> Logger.debug("hello") end
@@ -305,7 +305,7 @@ defmodule LoggerJSONDatadogTest do
   end
 
   test "logs hostname when set to string" do
-    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: "testing"])
+    Logger.configure_backend(LoggerJSON, formatter_opts: %{hostname: "testing"})
 
     log =
       fn -> Logger.debug("hello") end

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -281,6 +281,40 @@ defmodule LoggerJSONDatadogTest do
            end) == ""
   end
 
+  test "logs hostname when set to :system" do
+    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: :system])
+    {:ok, hostname} = :inet.gethostname()
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert log["syslog"]["hostname"] == to_string(hostname)
+  end
+
+  test "does not log hostname when set to :unset" do
+    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: :unset])
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert log["syslog"]["hostname"] == nil
+  end
+
+  test "logs hostname when set to string" do
+    Logger.configure_backend(LoggerJSON, formatter_opts: [hostname: "testing"])
+
+    log =
+      fn -> Logger.debug("hello") end
+      |> capture_log()
+      |> Jason.decode!()
+
+    assert log["syslog"]["hostname"] == "testing"
+  end
+
   test "logs severity" do
     log =
       fn -> Logger.debug("hello") end

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -15,7 +15,8 @@ defmodule LoggerJSONDatadogTest do
         metadata: [],
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: DatadogLogger
+        formatter: DatadogLogger,
+        formatter_state: []
       )
 
     :ok = Logger.reset_metadata([])

--- a/test/unit/logger_json_google_error_reporter_test.exs
+++ b/test/unit/logger_json_google_error_reporter_test.exs
@@ -12,7 +12,8 @@ defmodule LoggerJSONGoogleErrorReporterTest do
         metadata: :all,
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: GoogleCloudLogger
+        formatter: GoogleCloudLogger,
+        formatter_state: []
       )
 
     :ok = Logger.reset_metadata([])

--- a/test/unit/logger_json_google_error_reporter_test.exs
+++ b/test/unit/logger_json_google_error_reporter_test.exs
@@ -13,7 +13,7 @@ defmodule LoggerJSONGoogleErrorReporterTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: GoogleCloudLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
 
     :ok = Logger.reset_metadata([])

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -15,7 +15,8 @@ defmodule LoggerJSONGoogleTest do
         metadata: [],
         json_encoder: Jason,
         on_init: :disabled,
-        formatter: GoogleCloudLogger
+        formatter: GoogleCloudLogger,
+        formatter_state: []
       )
 
     :ok = Logger.reset_metadata([])

--- a/test/unit/logger_json_google_test.exs
+++ b/test/unit/logger_json_google_test.exs
@@ -16,7 +16,7 @@ defmodule LoggerJSONGoogleTest do
         json_encoder: Jason,
         on_init: :disabled,
         formatter: GoogleCloudLogger,
-        formatter_state: []
+        formatter_state: %{}
       )
 
     :ok = Logger.reset_metadata([])


### PR DESCRIPTION
## What is breaking

When logging to Datadog from a kubernetes cluster, the syslog hostname is set to the container hostname. This means Datadog will try to use the container hostname as the actual host name for metrics, traces, etc. Because of this, nothing will link up successfully. Sadly you can't rewrite that or do some sort of pipeline fix for this.

## Why this change fixes it

Removing the syslog hostname means that dd-agent will fall back to its native hostname logic. This will pick up the same hostname when running on a regular server (non containerized), and it will pick up the correct (node) host name when running in a container (kubernetes).