### PR TITLE
feat: allow converting otel trace ids to datadog values

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -94,17 +94,17 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
   # https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=go
   # Tests were stolen from https://github.com/open-telemetry/opentelemetry-specification/issues/525
   # and https://go.dev/play/p/pUBHcLdXJNy
-  defp convert_otel_field(value) do
-    value = to_string(value)
-    value_len = String.length(value)
+  defp convert_otel_field(<<value::binary-size(16)>>) do
+    {value, _} = Integer.parse(value, 16)
+    Integer.to_string(value, 10)
+  rescue
+    _ -> ""
+  end
 
-    if value_len >= 16 do
-      value = String.slice(value, value_len - 16, 16)
-      {value, _} = Integer.parse(value, 16)
-      Integer.to_string(value, 10)
-    else
-      ""
-    end
+  defp convert_otel_field(value) do
+    len = byte_size(value) - 16
+    <<_front::binary-size(len), value::binary>> = value
+    convert_otel_field(value)
   rescue
     _ -> ""
   end

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -73,8 +73,8 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
   # https://docs.datadoghq.com/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=jsonlogs
   defp convert_tracing_keys(output, md) do
     fields = %{
-      span_id: ["dd.span_id", &(&1)],
-      trace_id: ["dd.trace_id", &(&1)],
+      span_id: ["dd.span_id", & &1],
+      trace_id: ["dd.trace_id", & &1],
       otel_span_id: ["dd.span_id", &convert_otel_field/1],
       otel_trace_id: ["dd.trace_id", &convert_otel_field/1]
     }

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -101,7 +101,10 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
     _ -> ""
   end
 
+  defp convert_otel_field(value) when byte_size(value) < 16, do: ""
+
   defp convert_otel_field(value) do
+    value = to_string(value)
     len = byte_size(value) - 16
     <<_front::binary-size(len), value::binary>> = value
     convert_otel_field(value)

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -226,7 +226,12 @@ defmodule LoggerJSONDatadogTest do
 
     test "convert otel_trace_id/otel_span_id to expected datadog keys" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
-      Logger.metadata(otel_trace_id: <<98, 56, 49, 48, 100, 98, 97, 50, 57, 56, 48, 51, 101, 101, 54, 49, 101, 55, 99, 55, 49, 102, 102, 48, 99, 50, 99, 57, 53, 97, 57, 100>>)
+
+      Logger.metadata(
+        otel_trace_id:
+          <<98, 56, 49, 48, 100, 98, 97, 50, 57, 56, 48, 51, 101, 101, 54, 49, 101, 55, 99, 55, 49, 102, 102, 48, 99,
+            50, 99, 57, 53, 97, 57, 100>>
+      )
 
       log =
         fn -> Logger.debug("hello") end

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -224,7 +224,7 @@ defmodule LoggerJSONDatadogTest do
       assert Map.has_key?(log, "span_id") == false
     end
 
-    test "convert otel_trace_id/otel_span_id to expected datadog keys" do
+    test "convert otel_trace_id/otel_span_id binary to expected datadog keys" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
 
       Logger.metadata(
@@ -239,6 +239,48 @@ defmodule LoggerJSONDatadogTest do
         |> Jason.decode!()
 
       assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert Map.has_key?(log, "trace_id") == false
+      assert Map.has_key?(log, "span_id") == false
+    end
+
+    test "convert otel_trace_id/otel_span_id charlist to expected datadog keys" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      Logger.metadata(otel_trace_id: 'b810dba29803ee61e7c71ff0c2c95a9d')
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert Map.has_key?(log, "trace_id") == false
+      assert Map.has_key?(log, "span_id") == false
+    end
+
+    test "convert otel_trace_id/otel_span_id string to expected datadog keys" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      Logger.metadata(otel_trace_id: "e7c71ff0c2c95a9d")
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert Map.has_key?(log, "trace_id") == false
+      assert Map.has_key?(log, "span_id") == false
+    end
+
+    test "does not error on incorrect otel_trace_id/otel_span_id metadata" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      Logger.metadata(otel_trace_id: {:noop})
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"dd.trace_id" => ""} = log
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -223,6 +223,20 @@ defmodule LoggerJSONDatadogTest do
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end
+
+    test "convert otel_trace_id/otel_span_id to expected datadog keys" do
+      Logger.configure_backend(LoggerJSON, metadata: :all)
+      Logger.metadata(otel_trace_id: <<98, 56, 49, 48, 100, 98, 97, 50, 57, 56, 48, 51, 101, 101, 54, 49, 101, 55, 99, 55, 49, 102, 102, 48, 99, 50, 99, 57, 53, 97, 57, 100>>)
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert Map.has_key?(log, "trace_id") == false
+      assert Map.has_key?(log, "span_id") == false
+    end
   end
 
   describe "on_init/1 callback" do


### PR DESCRIPTION
This is to allow Open Telemetry trace ids to be converted into Datadog format so logs and traces can be linked together. Datadog has a [page on how to do this](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=go). Most of the code was stollen from the golang example, and then the test values were stollen from known good versions based off that go code. You'll notice that the code is very defensive in case some bad value gets there and starts breaking things. ~I'll also mention that this is probably not the most optimized version. I'm not great with binary pattern matching so improvements welcome.~

Currently this is what would show up out of the box in Datadog with https://github.com/open-telemetry/opentelemetry-erlang setup.
![image](https://user-images.githubusercontent.com/3385679/192855067-edf40cb0-9e4b-47bf-b525-1d06b889e63a.png)

**Note** I'm going to be running this locally for a bit on a project in production to ensure nothing breaks and works as intended.