### PR TITLE
Update LoggerJSON.Plug doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ It's [available on Hex](https://hex.pm/packages/logger_json), the package can be
   plug LoggerJSON.Plug
   ```
 
+  `LoggerJSON.Plug` is configured by default to use `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger`.
+  You can replace it with the `:metadata_formatter` config option.
+
   5. Optionally. Use Ecto telemetry for additional metadata:
 
   Attach telemetry handler for Ecto events in `start/2` function in `application.ex`

--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -22,6 +22,7 @@ if Code.ensure_loaded?(Plug) do
 
     ### Available metadata formatters
 
+      * `LoggerJSON.Plug.MetadataFormatters.DatadogLogger` see module for logged structure;
       * `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger` leverages GCP LogEntry format;
       * `LoggerJSON.Plug.MetadataFormatters.ELK` see module for logged structure.
 


### PR DESCRIPTION
Added the missing `LoggerJSON.Plug.MetadataFormatters.DatadogLogger` to the list of available metadata formatters.
And also some details in the readme regarding the default use of GoogleCloudLogger for the metadata formatter (which was not obvious to find in the LoggerJSON.Plug module, when configuring the logger for Datadog) .