### PR TITLE
Fix the inconsistency between the formatter init

### DIFF
--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -11,7 +11,7 @@ defmodule LoggerJSON.Formatter do
 
   Returned list will be used as formatter_state in `format_event/6`.
   """
-  @callback init(Keyword.t()) :: Keyword.t()
+  @callback init(map()) :: map()
 
   @doc """
   Format event callback.

--- a/lib/logger_json/formatters/basic_logger.ex
+++ b/lib/logger_json/formatters/basic_logger.ex
@@ -12,7 +12,7 @@ defmodule LoggerJSON.Formatters.BasicLogger do
   @processed_metadata_keys ~w[pid file line function module application]a
 
   @impl true
-  def init(_formatter_opts), do: []
+  def init(_formatter_opts), do: %{}
 
   @impl true
   def format_event(level, msg, ts, md, md_keys, _formatter_state) do

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -20,7 +20,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
   ]
 
   @impl true
-  def init(_formatter_opts), do: []
+  def init(_formatter_opts), do: %{}
 
   @doc """
   Builds structured payload which is mapped to Google Cloud Logger


### PR DESCRIPTION
The `@callback` spec for the formatter `init` function was speced with a keyword list but the actual type is a map. This changes the spec and the two existing implemenations that returned lists to return maps.

Fixes #95