### PR TITLE
Convert otel_trace_id, otel_span_id into strings

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -77,6 +77,8 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
     [
       otel_span_id: {"dd.span_id", &convert_otel_field/1},
       otel_trace_id: {"dd.trace_id", &convert_otel_field/1},
+      otel_span_id: {"otel_span_id", &otel_to_string/1},
+      otel_trace_id: {"otel_trace_id", &otel_to_string/1},
       span_id: {"dd.span_id", & &1},
       trace_id: {"dd.trace_id", & &1}
     ]
@@ -109,6 +111,13 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
     len = byte_size(value) - 16
     <<_front::binary-size(len), value::binary>> = value
     convert_otel_field(value)
+  rescue
+    _ -> ""
+  end
+
+  # convert to a binary if it's a charlist
+  defp otel_to_string(id) do
+    to_string(id)
   rescue
     _ -> ""
   end

--- a/test/unit/logger_json/formatters/datadog_logger_test.exs
+++ b/test/unit/logger_json/formatters/datadog_logger_test.exs
@@ -246,23 +246,23 @@ defmodule LoggerJSONDatadogTest do
     test "convert otel_trace_id/otel_span_id binary to expected datadog keys" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
 
-      Logger.metadata(
-        otel_trace_id:
-          <<98, 56, 49, 48, 100, 98, 97, 50, 57, 56, 48, 51, 101, 101, 54, 49, 101, 55, 99, 55, 49, 102, 102, 48, 99,
-            50, 99, 57, 53, 97, 57, 100>>
-      )
+      otel_id =
+        <<98, 56, 49, 48, 100, 98, 97, 50, 57, 56, 48, 51, 101, 101, 54, 49, 101, 55, 99, 55, 49, 102, 102, 48, 99, 50,
+          99, 57, 53, 97, 57, 100>>
+
+      Logger.metadata(otel_trace_id: otel_id)
 
       log =
         fn -> Logger.debug("hello") end
         |> capture_log()
         |> Jason.decode!()
 
-      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert %{"dd.trace_id" => "16701352862047361693", "otel_trace_id" => ^otel_id} = log
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end
 
-    test "convert otel_trace_id/otel_span_id charlist to expected datadog keys" do
+    test "convert otel_trace_id/otel_span_id charlist to string and expected datadog keys" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
       Logger.metadata(otel_trace_id: 'b810dba29803ee61e7c71ff0c2c95a9d')
 
@@ -271,21 +271,22 @@ defmodule LoggerJSONDatadogTest do
         |> capture_log()
         |> Jason.decode!()
 
-      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert %{"dd.trace_id" => "16701352862047361693", "otel_trace_id" => "b810dba29803ee61e7c71ff0c2c95a9d"} = log
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end
 
     test "convert otel_trace_id/otel_span_id string to expected datadog keys" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
-      Logger.metadata(otel_trace_id: "e7c71ff0c2c95a9d")
+      otel_id = "e7c71ff0c2c95a9d"
+      Logger.metadata(otel_trace_id: otel_id)
 
       log =
         fn -> Logger.debug("hello") end
         |> capture_log()
         |> Jason.decode!()
 
-      assert %{"dd.trace_id" => "16701352862047361693"} = log
+      assert %{"dd.trace_id" => "16701352862047361693", "otel_trace_id" => ^otel_id} = log
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end
@@ -299,7 +300,7 @@ defmodule LoggerJSONDatadogTest do
         |> capture_log()
         |> Jason.decode!()
 
-      assert %{"dd.trace_id" => ""} = log
+      assert %{"dd.trace_id" => "", "otel_trace_id" => ""} = log
       assert Map.has_key?(log, "trace_id") == false
       assert Map.has_key?(log, "span_id") == false
     end


### PR DESCRIPTION
These values are charlists coming from the Erlang opentelemetry library, so when they are JSON serialized they are turned into an array of integers.

This should be a string so it's logged as a useful value.
