### PR TITLE
Correct callback spec for `format_event/6`

### DIFF
--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -22,8 +22,8 @@ defmodule LoggerJSON.Formatter do
               level :: Logger.level(),
               msg :: Logger.message(),
               ts :: Logger.Formatter.time(),
-              md :: [atom] | :all,
-              state :: map,
-              formatter_state :: map
-            ) :: map | iodata() | %Jason.Fragment{}
+              md :: Keyword.t(),
+              md_keys :: [atom()] | :all,
+              formatter_state :: Map.t()
+            ) :: Map.t() | iodata() | %Jason.Fragment{}
 end


### PR DESCRIPTION
I believe the current callback for format_event is incorrect.

Currently the callback is defined as

```elixir
  @callback format_event(
              level :: Logger.level(),
              msg :: Logger.message(),
              ts :: Logger.Formatter.time(),
              md :: [atom] | :all,
              state :: map,
              formatter_state :: map
            ) :: map | iodata() | %Jason.Fragment{}
```

but at the call site the function is called like this

```elixir
    event = formatter.format_event(level, msg, ts, md, md_keys, formatter_state)
```

I have updated the callback spec to reflect the actual arguments so it now
reflects the correct types for `md` and swaps `state` to `md_keys` with the
correct type

```elixir
  @callback format_event(
              level :: Logger.level(),
              msg :: Logger.message(),
              ts :: Logger.Formatter.time(),
              md :: Keyword.t(),
              md_keys :: [atom()] | :all,
              formatter_state :: Map.t()
            ) :: Map.t() | iodata() | %Jason.Fragment{}
```

Thank you for maintaining this Library!
