### PR TITLE
Add phoenix logger w/ telemetry events

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,31 @@ It's [available on Hex](https://hex.pm/packages/logger_json), the package can be
   `LoggerJSON.Plug` is configured by default to use `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger`.
   You can replace it with the `:metadata_formatter` config option.
 
+  Or for a Phoenix application
+
+  ```ex
+  config :phoenix, :logger, false
+  ```
+
+  ```ex
+  # application.ex
+  def start(_type, _args) do
+    LoggerJSON.Phoenix.Logger.install()
+    ...
+  end
+  ```
+
+  `LoggerJSON.Phoenix.Logger` is configured by default to use `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger`.
+  You can replace it with the `:metadata_formatter` config option.
+
+  ```ex
+  # application.ex
+  def start(_type, _args) do
+    LoggerJSON.Phoenix.Logger.install(metadata_formatter: LoggerJSON.Plug.MetadataFormatters.DatadogFormatter)
+    ...
+  end
+  ```
+
   5. Optionally. Use Ecto telemetry for additional metadata:
 
   Attach telemetry handler for Ecto events in `start/2` function in `application.ex`

--- a/lib/logger_json/phoenix/logger.ex
+++ b/lib/logger_json/phoenix/logger.ex
@@ -1,0 +1,53 @@
+defmodule LoggerJSON.Phoenix.Logger do
+  require Logger
+  import Phoenix.Logger, only: [duration: 1]
+
+  @default_opts [
+    version_header: "x-api-version",
+    metadata_formatter: LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger,
+    duration_unit: :nanosecond
+  ]
+
+  @spec install(opts :: list()) :: any()
+  def install(opts \\ []) do
+    opts = Keyword.merge(@default_opts, opts)
+
+    handlers = %{
+      [:phoenix, :endpoint, :stop] => &__MODULE__.phoenix_endpoint_stop/4
+    }
+
+    for {key, fun} <- handlers do
+      :telemetry.attach({__MODULE__, key}, key, fun, opts)
+    end
+  end
+
+  def phoenix_endpoint_stop(_event, %{duration: duration}, %{conn: conn} = metadata, config) do
+    case log_level(metadata[:options][:log], conn) do
+      false ->
+        :ok
+
+      level ->
+        version_header = Keyword.get(config, :version_header)
+        metadata_formatter = Keyword.get(config, :metadata_formatter)
+        unit = Keyword.get(config, :duration_unit)
+        metadata = metadata_formatter.build_metadata(conn, duration, version_header, unit: unit)
+
+        Logger.log(
+          level,
+          fn ->
+            %{status: status, method: method} = conn
+            status_str = Integer.to_string(status)
+            [method, " ", conn.request_path, " returns ", status_str, " in ", duration(duration)]
+          end,
+          metadata
+        )
+    end
+  end
+
+  defp log_level(nil, _conn), do: :info
+  defp log_level(level, _conn) when is_atom(level), do: level
+
+  defp log_level({mod, fun, args}, conn) when is_atom(mod) and is_atom(fun) and is_list(args) do
+    apply(mod, fun, [conn | args])
+  end
+end

--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -30,18 +30,20 @@ if Code.ensure_loaded?(Plug) do
     @impl true
     def init(opts) do
       level = Keyword.get(opts, :log, :info)
+      unit = Keyword.get(opts, :unit, :nanosecond)
+      metadata_opts = [unit: unit]
       client_version_header = Keyword.get(opts, :version_header, "x-api-version")
       metadata_formatter = Keyword.get(opts, :metadata_formatter, MetadataFormatters.GoogleCloudLogger)
-      {level, metadata_formatter, client_version_header}
+      {level, metadata_formatter, client_version_header, metadata_opts}
     end
 
     @impl true
-    def call(conn, {level, metadata_formatter, client_version_header}) do
+    def call(conn, {level, metadata_formatter, client_version_header, metadata_opts}) do
       start = System.monotonic_time()
 
       Conn.register_before_send(conn, fn conn ->
         latency = System.monotonic_time() - start
-        metadata = metadata_formatter.build_metadata(conn, latency, client_version_header)
+        metadata = metadata_formatter.build_metadata(conn, latency, client_version_header, metadata_opts)
         Logger.log(level, "", metadata)
         conn
       end)

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -10,11 +10,13 @@ if Code.ensure_loaded?(Plug) do
     import Jason.Helpers, only: [json_map: 1]
 
     @doc false
-    def build_metadata(conn, latency, client_version_header) do
+    def build_metadata(conn, latency, client_version_header, opts \\ []) do
+      unit = Keyword.get(opts, :unit, :nanosecond)
+
       client_metadata(conn, client_version_header) ++
         phoenix_metadata(conn) ++
         [
-          duration: native_to_nanoseconds(latency),
+          duration: native_to_unit(latency, unit),
           http:
             json_map(
               url: request_url(conn),
@@ -36,12 +38,12 @@ if Code.ensure_loaded?(Plug) do
         ]
     end
 
-    defp native_to_nanoseconds(nil) do
+    defp native_to_unit(nil, _) do
       nil
     end
 
-    defp native_to_nanoseconds(native) do
-      System.convert_time_unit(native, :native, :nanosecond)
+    defp native_to_unit(native, unit) do
+      System.convert_time_unit(native, :native, unit)
     end
 
     defp request_url(%{request_path: "/"} = conn), do: "#{conn.scheme}://#{conn.host}/"

--- a/lib/logger_json/plug/metadata_formatters/elk.ex
+++ b/lib/logger_json/plug/metadata_formatters/elk.ex
@@ -19,7 +19,7 @@ if Code.ensure_loaded?(Plug) do
     import Jason.Helpers, only: [json_map: 1]
 
     @doc false
-    def build_metadata(conn, latency, client_version_header) do
+    def build_metadata(conn, latency, client_version_header, _) do
       latency_μs = System.convert_time_unit(latency, :native, :microsecond)
       user_agent = LoggerJSON.PlugUtils.get_header(conn, "user-agent")
       ip = LoggerJSON.PlugUtils.remote_ip(conn)

--- a/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/google_cloud_logger.ex
@@ -15,7 +15,7 @@ if Code.ensure_loaded?(Plug) do
     @nanoseconds_in_second System.convert_time_unit(1, :second, :nanosecond)
 
     @doc false
-    def build_metadata(conn, latency, client_version_header) do
+    def build_metadata(conn, latency, client_version_header, _) do
       latency_seconds = native_to_seconds(latency)
       request_method = conn.method
       request_url = request_url(conn)

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule LoggerJSON.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :telemetry]
     ]
   end
 

--- a/test/unit/logger_json/phoenix/logger_test.exs
+++ b/test/unit/logger_json/phoenix/logger_test.exs
@@ -1,0 +1,117 @@
+defmodule LoggerJSON.Phoenix.LoggerTest do
+  use Logger.Case, async: false
+  use Plug.Test
+
+  setup do
+    LoggerJSON.Phoenix.Logger.install(metadata_formatter: LoggerJSON.Plug.MetadataFormatters.DatadogLogger)
+
+    on_exit(fn ->
+      :telemetry.detach([:phoenix, :endpoint, :stop])
+    end)
+
+    telemetry_opts = Plug.Telemetry.init(event_prefix: [:phoenix, :endpoint])
+    :ok = Logger.reset_metadata([])
+    request_id = Ecto.UUID.generate()
+
+    conn =
+      conn(:get, "/")
+      |> Plug.Conn.put_resp_header("x-request-id", request_id)
+      |> Plug.Conn.put_req_header("user-agent", "chrome")
+      |> Plug.Conn.put_req_header("referer", "http://google.com")
+      |> Plug.Conn.put_req_header("x-forwarded-for", "127.0.0.10")
+      |> Plug.Conn.put_req_header("x-api-version", "2017-01-01")
+
+    {:ok, conn: conn, telemetry_opts: telemetry_opts}
+  end
+
+  describe "basic logger formatter" do
+    setup do
+      Logger.configure_backend(
+        LoggerJSON,
+        device: :user,
+        level: :info,
+        metadata: :all,
+        json_encoder: Jason,
+        on_init: :disabled,
+        formatter: LoggerJSON.Formatters.BasicLogger,
+        formatter_state: %{}
+      )
+
+      :ok = Logger.reset_metadata([])
+    end
+
+    test "w/ default datadog metadata", %{conn: conn, telemetry_opts: telemetry_opts} do
+      assert raw_log =
+               capture_log(:info, fn ->
+                 Plug.Telemetry.call(conn, telemetry_opts) |> Plug.Conn.send_resp(200, "{}")
+               end)
+
+      assert is_binary(raw_log)
+      assert log = Jason.decode!(raw_log)
+      assert log["message"] =~ "GET / returns 200 in"
+      assert log["severity"] == "info"
+      assert log["time"]
+      assert log["metadata"]["duration"]
+
+      assert %{
+               "method" => "GET",
+               "referer" => "http://google.com",
+               "status_code" => 200,
+               "url" => "http://www.example.com/",
+               "url_details" => %{
+                 "host" => "www.example.com",
+                 "path" => "/",
+                 "port" => 80,
+                 "queryString" => "",
+                 "scheme" => "http"
+               },
+               "useragent" => "chrome"
+             } = log["metadata"]["http"]
+    end
+  end
+
+  describe "datadog logger formatter" do
+    setup do
+      Logger.configure_backend(
+        LoggerJSON,
+        device: :user,
+        level: :info,
+        metadata: :all,
+        json_encoder: Jason,
+        on_init: :disabled,
+        formatter: LoggerJSON.Formatters.DatadogLogger,
+        formatter_state: %{}
+      )
+
+      :ok = Logger.reset_metadata([])
+    end
+
+    test "w/ default datadog metadata", %{conn: conn, telemetry_opts: telemetry_opts} do
+      assert raw_log =
+               capture_log(:info, fn ->
+                 Plug.Telemetry.call(conn, telemetry_opts) |> Plug.Conn.send_resp(200, "{}")
+               end)
+
+      assert is_binary(raw_log)
+      assert log = Jason.decode!(raw_log)
+      assert log["message"] =~ "GET / returns 200 in"
+      assert log["syslog"]["severity"] == "info"
+      assert log["network"] == %{"client" => %{"ip" => "127.0.0.10"}}
+
+      assert %{
+               "method" => "GET",
+               "referer" => "http://google.com",
+               "status_code" => 200,
+               "url" => "http://www.example.com/",
+               "url_details" => %{
+                 "host" => "www.example.com",
+                 "path" => "/",
+                 "port" => 80,
+                 "queryString" => "",
+                 "scheme" => "http"
+               },
+               "useragent" => "chrome"
+             } = log["http"]
+    end
+  end
+end


### PR DESCRIPTION
Add ability to use telemetry events to log phoenix requests. 
This logger has the following options:
- `metadata_formatter` default to `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger`
- `version_header` default to `x-api-version`
- `unit` (only for datadog for now) to choose the unit of the duration.