### PR TITLE
Add ignored_metadata option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ rel/*/
 # Don't commit file uploads
 uploads/
 !uploads/.gitkeep
+/logger_json.iml

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ It's [available on Hex](https://hex.pm/packages/logger_json), the package can be
 
   ```ex
   def deps do
-    [{:logger_json, "~> 5.1"}]
+    [{:logger_json, "~> 5.2"}]
   end
   ```
 
@@ -176,7 +176,10 @@ It's [available on Hex](https://hex.pm/packages/logger_json), the package can be
 
   ```
 
-  Some integrations (for eg. Plug) use `metadata` to log request and response parameters. You can reduce log size by replacing `:all` (which means log all metadata) with a list of the ones that you actually need. 
+  Some integrations (for eg. Plug) use `metadata` to log request and response parameters.
+
+  You can reduce log size by replacing `:all` (which means log all metadata) with a list of the ones that you actually need, OR
+  you can combine `:all` with `ignored_metadata: [:atom1, ...]` to exclude specific items instead. 
 
   Beware that LoggerJSON always ignores [some metadata keys](https://github.com/Nebo15/logger_json/blob/349c8174886135a02bb16317f76beac89d1aa20d/lib/logger_json.ex#L46), but formatters like `GoogleCloudLogger` and `DatadogLogger` still persist those metadata values into a structured output. This behavior is similar to the default Elixir logger backend.
 

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -23,6 +23,7 @@ defmodule LoggerJSON.Formatter do
               msg :: Logger.message(),
               ts :: Logger.Formatter.time(),
               md :: [atom] | :all,
+              imd :: [atom],
               state :: map,
               formatter_state :: map
             ) :: map | iodata() | %Jason.Fragment{}

--- a/lib/logger_json/formatters/basic_logger.ex
+++ b/lib/logger_json/formatters/basic_logger.ex
@@ -15,18 +15,18 @@ defmodule LoggerJSON.Formatters.BasicLogger do
   def init(_formatter_opts), do: []
 
   @impl true
-  def format_event(level, msg, ts, md, md_keys, _formatter_state) do
+  def format_event(level, msg, ts, md, md_keys, imd_keys, _formatter_state) do
     json_map(
       time: FormatterUtils.format_timestamp(ts),
       severity: Atom.to_string(level),
       message: IO.chardata_to_string(msg),
-      metadata: format_metadata(md, md_keys)
+      metadata: format_metadata(md, md_keys, imd_keys)
     )
   end
 
-  defp format_metadata(md, md_keys) do
+  defp format_metadata(md, md_keys, imd_keys) do
     md
-    |> LoggerJSON.take_metadata(md_keys, @processed_metadata_keys)
+    |> LoggerJSON.take_metadata(md_keys, @processed_metadata_keys ++ imd_keys)
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))
     |> JasonSafeFormatter.format()
   end

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -46,7 +46,7 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
   end
 
   @impl true
-  def format_event(level, msg, ts, md, md_keys, formatter_state) do
+  def format_event(level, msg, ts, md, md_keys, imd_keys, formatter_state) do
     Map.merge(
       %{
         logger:
@@ -59,12 +59,12 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
         message: IO.chardata_to_string(msg),
         syslog: syslog(level, ts, formatter_state.hostname)
       },
-      format_metadata(md, md_keys)
+      format_metadata(md, md_keys, imd_keys)
     )
   end
 
-  defp format_metadata(md, md_keys) do
-    LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys)
+  defp format_metadata(md, md_keys, imd_keys) do
+    LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys ++ imd_keys)
     |> convert_tracing_keys(md)
     |> JasonSafeFormatter.format()
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -30,32 +30,32 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
   """
   for {level, gcp_level} <- @severity_levels do
     @impl true
-    def format_event(unquote(level), msg, ts, md, md_keys, _formatter_state) do
+    def format_event(unquote(level), msg, ts, md, md_keys, imd_keys, _formatter_state) do
       Map.merge(
         %{
           time: FormatterUtils.format_timestamp(ts),
           severity: unquote(gcp_level),
           message: IO.chardata_to_string(msg)
         },
-        format_metadata(md, md_keys)
+        format_metadata(md, md_keys, imd_keys)
       )
     end
   end
 
   @impl true
-  def format_event(_level, msg, ts, md, md_keys, _formatter_state) do
+  def format_event(_level, msg, ts, md, md_keys, imd_keys, _formatter_state) do
     Map.merge(
       %{
         time: FormatterUtils.format_timestamp(ts),
         severity: "DEFAULT",
         message: IO.chardata_to_string(msg)
       },
-      format_metadata(md, md_keys)
+      format_metadata(md, md_keys, imd_keys)
     )
   end
 
-  defp format_metadata(md, md_keys) do
-    LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys)
+  defp format_metadata(md, md_keys, imd_keys) do
+    LoggerJSON.take_metadata(md, md_keys, @processed_metadata_keys ++ imd_keys)
     |> JasonSafeFormatter.format()
     |> FormatterUtils.maybe_put(:error, FormatterUtils.format_process_crash(md))
     |> FormatterUtils.maybe_put(:"logging.googleapis.com/sourceLocation", format_source_location(md))

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule LoggerJSON.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/Nebo15/logger_json"
-  @version "5.1.2"
+  @version "5.2.0"
 
   def project do
     [

--- a/test/unit/logger_json/formatters/basic_logger_test.exs
+++ b/test/unit/logger_json/formatters/basic_logger_test.exs
@@ -67,6 +67,23 @@ defmodule LoggerJSON.Formatters.BasicLoggerTest do
       assert %{} == log["metadata"]
     end
 
+    test "can have ignored_metadata" do
+      Logger.configure_backend(LoggerJSON, metadata: :all, ignored_metadata: [:pii])
+
+      Logger.metadata(user_id: 11)
+      Logger.metadata(dynamic_metadata: 5)
+      Logger.metadata(pii: "secret")
+
+      log =
+        fn -> Logger.debug("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"message" => "hello"} = log
+      assert %{"user_id" => 11, "dynamic_metadata" => 5} = log["metadata"]
+      assert is_nil(log["metadata"]["pii"])
+    end
+
     test "converts Struct metadata to maps" do
       Logger.configure_backend(LoggerJSON, metadata: :all)
 


### PR DESCRIPTION
Remembering to add metadata fields to the matadata list is problematic, so here is a version that allows you to rather have a black list of tags you don't want which are added to the existing black list. 

```
config :logger_json, :backend,
       metadata: :all,
       ignored_metadata: [:domain, :erl_level],
       json_encoder: Jason,
       formatter: LoggerJSON.Formatters.BasicLogger
```