### PR TITLE
feat: Use erl_level as severity

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -46,6 +46,9 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
   end
 
   @impl true
+  def format_event(:warning, msg, ts, md, md_keys, formatter_state),
+    do: format_event(:warn, msg, ts, md, md_keys, formatter_state)
+
   def format_event(level, msg, ts, md, md_keys, formatter_state) do
     Map.merge(
       %{

--- a/lib/logger_json/formatters/google_cloud_logger.ex
+++ b/lib/logger_json/formatters/google_cloud_logger.ex
@@ -15,8 +15,13 @@ defmodule LoggerJSON.Formatters.GoogleCloudLogger do
   @severity_levels [
     {:debug, "DEBUG"},
     {:info, "INFO"},
+    {:notice, "NOTICE"},
     {:warn, "WARNING"},
-    {:error, "ERROR"}
+    {:warning, "WARNING"},
+    {:error, "ERROR"},
+    {:crit, "CRITICAL"},
+    {:alert, "ALERT"},
+    {:emerg, "EMERGENCY"}
   ]
 
   @impl true

--- a/test/unit/logger_json/formatters/datadog_logger_test.exs
+++ b/test/unit/logger_json/formatters/datadog_logger_test.exs
@@ -411,6 +411,17 @@ defmodule LoggerJSONDatadogTest do
     assert %{"syslog" => %{"severity" => "warn"}} = log
   end
 
+  if Version.compare(System.version(), "1.11.0") == :lt do
+    test "logs severity with erl_level" do
+      log =
+        fn -> Logger.notice("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"syslog" => %{"severity" => "notice"}} = log
+    end
+  end
+
   test "logs crash reason when present" do
     Logger.configure_backend(LoggerJSON, metadata: [:crash_reason])
     Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []})

--- a/test/unit/logger_json/formatters/google_cloud_logger_test.exs
+++ b/test/unit/logger_json/formatters/google_cloud_logger_test.exs
@@ -279,6 +279,17 @@ defmodule LoggerJSON.GoogleCloudLoggerTest do
     assert %{"severity" => "WARNING"} = log
   end
 
+  if Version.compare(System.version(), "1.11.0") != :lt do
+    test "logs severity with erl_level" do
+      log =
+        fn -> Logger.notice("hello") end
+        |> capture_log()
+        |> Jason.decode!()
+
+      assert %{"severity" => "NOTICE"} = log
+    end
+  end
+
   test "logs crash reason for exceptions when present" do
     Logger.configure_backend(LoggerJSON, metadata: [:crash_reason])
     Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []})


### PR DESCRIPTION
Since [Elixir 1.11.0](https://hexdocs.pm/elixir/1.11.4/changelog.html#v1-11-0-2020-10-06), Logger supports syslog levels such as notice, critical, alert, and emergency to be passed in Logger's erl_level metadata.

Google Cloud Logger LogEntry also supports these as LogSeverity:
https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity 

This PR makes these levels to be logged as severity.

Note that, for backward compatibility, this treats 'warn' as 'warning' level.
