### PR TITLE
Drop prefix from docs source ref

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule LoggerJSON.Mixfile do
       ],
       main: "readme",
       source_url: @source_url,
-      source_ref: "v#{@version}",
+      source_ref: @version,
       formatters: ["html"]
     ]
   end


### PR DESCRIPTION
The git tags do not have the `v` prefix so we need to drop it from the `source_ref` for the doc links to work :)