### PR TITLE
Add ability to dynamically compute log levels

### DIFF
--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -26,6 +26,27 @@ if Code.ensure_loaded?(Plug) do
       * `LoggerJSON.Plug.MetadataFormatters.GoogleCloudLogger` leverages GCP LogEntry format;
       * `LoggerJSON.Plug.MetadataFormatters.ELK` see module for logged structure.
 
+    ### Dynamic log level
+        
+        In some cases you may wish to set the log level dynamically
+        on a per-request basis. To do so, set the `:log` option to
+        a tuple, `{Mod, Fun, Args}`. The `Plug.Conn.t()` for the
+        request will be prepended to the provided list of arguments.
+        
+        When invoked, your function must return a
+        [`Logger.level()`](`t:Logger.level()/0`) or `false` to
+        disable logging for the request.
+        
+        For example, in your Endpoint you might do something like this:
+        
+              # lib/my_app_web/endpoint.ex
+              plug LoggerJSON.Plug,
+                log: {__MODULE__, :log_level, []}
+        
+              # Disables logging for routes like /status/*
+              def log_level(%{path_info: ["status" | _]}), do: false
+              def log_level(_), do: :info
+
     """
     @impl true
     def init(opts) do
@@ -38,13 +59,24 @@ if Code.ensure_loaded?(Plug) do
     @impl true
     def call(conn, {level, metadata_formatter, client_version_header}) do
       start = System.monotonic_time()
+      computed_level = level(level, conn)
 
-      Conn.register_before_send(conn, fn conn ->
-        latency = System.monotonic_time() - start
-        metadata = metadata_formatter.build_metadata(conn, latency, client_version_header)
-        Logger.log(level, "", metadata)
+      if computed_level do
+        Conn.register_before_send(conn, fn conn ->
+          latency = System.monotonic_time() - start
+          metadata = metadata_formatter.build_metadata(conn, latency, client_version_header)
+          Logger.log(computed_level, "", metadata)
+          conn
+        end)
+      else
         conn
-      end)
+      end
+    end
+
+    defp level(level, _conn) when is_atom(level), do: level
+
+    defp level({mod, func, args}, conn) do
+      apply(mod, func, [conn | args])
     end
   end
 end


### PR DESCRIPTION
Similar to the behavior in Phoenix.Logger, allow dynamical computation of log levels. This allows users to do things like suppress logs for health checks.