### PR TITLE
Correct Formatter TypeSpec

### DIFF
--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -22,8 +22,8 @@ defmodule LoggerJSON.Formatter do
               level :: Logger.level(),
               msg :: Logger.message(),
               ts :: Logger.Formatter.time(),
-              md :: [atom] | :all,
-              state :: map,
+              md :: Keyword.t(),
+              md_keys :: [atom] | :all
               formatter_state :: map
             ) :: map | iodata() | %Jason.Fragment{}
 end


### PR DESCRIPTION
Ref: `LoggerJSON.Formatter.format_event/6` callback TypeSpec.

1. The old `state` parameter was a `map` but when changes were made for the DataDog formatter from `LoggerJSON.Formatter.format_event/5` to `LoggerJSON.Formatter.format_event/6` the parameter did not get updated to reflect the correct typing.
2. `md` is marked as a `map` when this is actually a `Keyword.t`
