### PR TITLE
Translate warn to warning for Elixir >= 1.11.0

### DIFF
--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -172,6 +172,14 @@ defmodule LoggerJSON do
   defp put_env(env), do: Application.put_env(:logger_json, :backend, env)
 
   defp meet_level?(_lvl, nil), do: true
+  defp meet_level?(lvl, lvl), do: true
+
+  if Version.match?(System.version(), ">= 1.11.0") do
+    # This clause avoids `IO.warn/1` being triggered by Logger when using `:warn`.
+    defp meet_level?(:warn, min), do: Logger.compare_levels(:warning, min) != :lt
+    defp meet_level?(lvl, :warn), do: Logger.compare_levels(lvl, :warning) != :lt
+  end
+
   defp meet_level?(lvl, min), do: Logger.compare_levels(lvl, min) != :lt
 
   defp init(config, state) do


### PR DESCRIPTION
[Logger.compare_levels/2](https://hexdocs.pm/logger/Logger.html#compare_levels/2) triggers [IO.warn/1](https://hexdocs.pm/elixir/IO.html#warn/1) whenever we use it with `:warn` as parameter:

- https://github.com/elixir-lang/elixir/blob/v1.16.1/lib/logger/lib/logger.ex#L625-L630
- https://github.com/elixir-lang/elixir/blob/v1.16.1/lib/logger/lib/logger.ex#L1164-L1167

Sadly, any backend configured for `Logger` will translate `:warning` level to `:warn` for backward compatibility ([ref](https://hexdocs.pm/logger_backends/LoggerBackends.html#module-custom-backends)), which makes the current implementation of this library to always trigger the `IO` warn message for warning logs.

This PR addresses that by converting the log `:warn` level to `:warning` before calling `Logger.compare_levels/2` for Elixir `>= 1.11.0`.