### PR TITLE
Make pretty JSON formatting optional in basic formatter

### DIFF
--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -44,7 +44,7 @@ defmodule LoggerJSON.Formatters.Basic do
       |> maybe_put(:request, format_http_request(meta))
       |> maybe_put(:span, format_span(meta))
       |> maybe_put(:trace, format_trace(meta))
-      |> Jason.encode_to_iodata!(pretty: true)
+      |> Jason.encode_to_iodata!()
 
     [line, "\n"]
   end


### PR DESCRIPTION
Some log processors can't process JSON logs if they are spread across multiple lines.

I saw the other formatters don't have `pretty` at all so I'm not sure if it's intentional.