### PR TITLE
fix(elastic): better support for logging raised and caught exceptions and fix formatter crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ Any custom metadata fields will be added to the root of the message, so that you
 > Note that this also allows you to produce messages that do not strictly adhere to the ECS specification.
 
 ```json
-// with Logger.metadata(:"device.model.name": "My Awesome Device")
+// Logger.info("Hello") with Logger.metadata(:"device.model.name": "My Awesome Device")
+// or Logger.info("Hello", "device.model.name": "My Awesome Device")
 {
   "@timestamp": "2024-05-21T15:17:35.374Z",
   "ecs.version": "8.11.0",

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -70,6 +70,9 @@ defmodule LoggerJSON do
 
     * `:conn` - the `Plug.Conn` struct. This is useful when logging HTTP requests and responses,
     each formatter may use it differently.
+    * `:crash_reason` - accepts a tuple where the first element is the exception struct
+    and the second is the stacktrace. For example: `Logger.error("Exception!", crash_reason: {e, __STACKTRACE__})`.
+    Each formatter may encode it differently.
   """
   @log_levels [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice]
   @log_level_strings Enum.map(@log_levels, &to_string/1)


### PR DESCRIPTION
Hi again :)

When using the Elastic logger in my work project, I noticed that the logging flow for caught exceptions is not very smooth, as I first have to call `Logger.metadata(crash_reason: e)` (where `e` is my caught exception) to save the error context before every `Logger.warning` or `Logger.error` or the like. Even worse, as a caller and especially someone inexperienced with `Logger`, there's no indication as to the lifetime of whatever is passed to `Logger.metadata`. Will it stay there until the next log, will it be included in every log from that point on? (spoiler alert, it's the latter, so you'd need to manually clear the crash reason in the metadata after the log).

tl;dr: this replaces

```elixir
try do
  raise "oops"
rescue
  e in RuntimeError -> 
      Logger.metadata(crash_reason: e)
      Logger.error("Something went wrong")
      Logger.metadata(crash_reason: nil)
end
```

```elixir
try do
  raise "oops"
rescue
  e in RuntimeError -> Logger.error("Something went wrong", crash_reason: e)
end
```