### PR TITLE
Formatter config can be a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ config :logger, :default_handler,
 or during runtime:
 
 ```elixir
-:logger.update_handler_config(:default, :formatter, {Basic, metadata: {:all_except, [:conn]}})
+:logger.update_handler_config(:default, :formatter, {Basic, %{metadata: {:all_except, [:conn]}}})
 ```
 
 ## Docs

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -38,7 +38,7 @@ defmodule LoggerJSON do
 
   or during runtime (eg. in your `application.ex`):
 
-      :logger.update_handler_config(:default, :formatter, {Basic, []})
+      :logger.update_handler_config(:default, :formatter, {Basic, %{}})
 
   ## Configuration
 
@@ -50,7 +50,7 @@ defmodule LoggerJSON do
 
   or during runtime:
 
-      :logger.update_handler_config(:default, :formatter, {Basic, metadata: {:all_except, [:conn]}})
+      :logger.update_handler_config(:default, :formatter, {Basic, %{metadata: {:all_except, [:conn]}}})
 
   ### Shared Options
 

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -26,6 +26,7 @@ defmodule LoggerJSON.Formatters.Basic do
 
   @impl true
   def format(%{level: level, meta: meta, msg: msg}, opts) do
+    opts = Keyword.new(opts)
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -50,6 +50,7 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   @impl true
   def format(%{level: level, meta: meta, msg: msg}, opts) do
+    opts = Keyword.new(opts)
     redactors = Keyword.get(opts, :redactors, [])
     hostname = Keyword.get(opts, :hostname, :system)
 

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -143,6 +143,7 @@ defmodule LoggerJSON.Formatters.Elastic do
 
   @impl LoggerJSON.Formatter
   def format(%{level: level, meta: meta, msg: msg}, opts) do
+    opts = Keyword.new(opts)
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -100,6 +100,7 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
 
   @impl true
   def format(%{level: level, meta: meta, msg: msg}, opts) do
+    opts = Keyword.new(opts)
     redactors = Keyword.get(opts, :redactors, [])
     service_context = Keyword.get_lazy(opts, :service_context, fn -> %{service: to_string(node())} end)
     project_id = Keyword.get(opts, :project_id)


### PR DESCRIPTION
The documentation mentions that you can configure the logger like this:

`:logger.update_handler_config(:default, :formatter, {Basic, []})`

However, this will give a dialyzer error, because `:logger.update_handler_config` requires the options to be a map: https://www.erlang.org/doc/apps/kernel/logger.html#update_handler_config/3 and https://www.erlang.org/doc/apps/kernel/logger.html#t:formatter_config/0.

This PR changes the `format/2` callback to supports `opts` that are maps and updates the docs so that users don't get dialyzer errors.