### PR TITLE
Keep native DateTime, Date and Time struct encoding

### DIFF
--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -32,6 +32,9 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode("[REDACTED]", _redactors), do: "[REDACTED]"
   def encode(binary, _redactors) when is_binary(binary), do: encode_binary(binary)
   def encode(%Jason.Fragment{} = fragment, _redactors), do: fragment
+  def encode(%DateTime{} = datetime, _redactors), do: datetime
+  def encode(%Date{} = date, _redactors), do: date
+  def encode(%Time{} = time, _redactors), do: time
 
   def encode(%_struct{} = struct, redactors) do
     struct

--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -36,6 +36,7 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode(%DateTime{} = datetime, _redactors), do: datetime
   def encode(%Date{} = date, _redactors), do: date
   def encode(%Time{} = time, _redactors), do: time
+  def encode(%Decimal{} = decimal, _redactors), do: decimal
 
   def encode(%_struct{} = struct, redactors) do
     struct

--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -32,6 +32,7 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode("[REDACTED]", _redactors), do: "[REDACTED]"
   def encode(binary, _redactors) when is_binary(binary), do: encode_binary(binary)
   def encode(%Jason.Fragment{} = fragment, _redactors), do: fragment
+  def encode(%NaiveDateTime{} = naive_datetime, _redactors), do: naive_datetime
   def encode(%DateTime{} = datetime, _redactors), do: datetime
   def encode(%Date{} = date, _redactors), do: date
   def encode(%Time{} = time, _redactors), do: time

--- a/test/logger_json/formatter/redactor_encoder_test.exs
+++ b/test/logger_json/formatter/redactor_encoder_test.exs
@@ -35,6 +35,17 @@ defmodule LoggerJSON.Formatter.RedactorEncoderTest do
       assert encode(123, @redactors) == 123
     end
 
+    test "allows dates and times" do
+      assert encode(~U[2024-01-01 00:00:00Z], @redactors) == ~U[2024-01-01 00:00:00Z]
+      assert encode(~N[2024-01-01 00:00:00], @redactors) == ~N[2024-01-01 00:00:00]
+      assert encode(~D[2024-01-01], @redactors) == ~D[2024-01-01]
+      assert encode(~T[00:00:00], @redactors) == ~T[00:00:00]
+    end
+
+    test "allows decimals" do
+      assert encode(Decimal.new("1.2"), @redactors) == Decimal.new("1.2")
+    end
+
     test "strips Structs" do
       assert encode(%IDStruct{id: "hello"}, @redactors) == %{id: "hello"}
     end


### PR DESCRIPTION
Right now dates and times are encoded with the struct encoder which makes the logs be very verbose about dates (I'm using Grafana Loki to view logs and it makes it hard to parse visually):
```elixir
%{level: :info, msg: {:string, "some message"}, meta: %{
  datetime: DateTime.utc_now(), 
  date: Date.utc_today(), 
  time: Time.utc_now
}}
|> LoggerJSON.Formatters.Basic.format(metadata: [:datetime, :date, :time]) 
|> IO.chardata_to_string()
|> Jason.decode! 
|> Jason.encode!(pretty: true) 
|> IO.puts 
```
```elixir
{                                                                                                                                                           
  "message": "some message",                                                                                                                 
  "metadata": {                                                                                                                              
    "date": {                                                                                                                                
      "calendar": "Elixir.Calendar.ISO",                                                                                                     
      "day": 29,                                                                                                                             
      "month": 7,                                                                                                                            
      "year": 2024                                                                                                                           
    },                                                                                                                                       
    "datetime": {                                                                                                                            
      "calendar": "Elixir.Calendar.ISO",                                                                                                     
      "day": 29,                                                                                                                             
      "hour": 16,                                                                                                                            
      "microsecond": [                                                                                                                       
        744919,                                                                                                                              
        6                                                                                                                                    
      ],                                                                                                                                     
      "minute": 45,                                                                                                                          
      "month": 7,     
      "second": 0,           
      "std_offset": 0,
      "time_zone": "Etc/UTC",
      "utc_offset": 0,                 
      "year": 2024,                    
      "zone_abbr": "UTC"               
    },                                 
    "time": {                          
      "calendar": "Elixir.Calendar.ISO",                                      
      "hour": 16,                      
      "microsecond": [                 
        744951,                        
        6                              
      ],                               
      "minute": 45,                    
      "second": 0                      
    }                                  
  },                                   
  "severity": "info",                  
  "time": "2024-07-29T16:45:00.744Z"                                          
} 
```
I propose to keep those as-is and let them be encoded by their native Jason encoding. They don't present any sensitive data and therefore they don't need to be checked for redacted fields.
```elixir
{                                                                                                                                                           
  "message": "some message",                                                                                                                                
  "metadata": {                                                                                                                                             
    "date": "2024-07-29",                                                                                                                                   
    "datetime": "2024-07-29T16:44:50.502282Z",                                                                                                              
    "time": "16:44:50.502331"                                                                                                                               
  },                                                                                                                                                        
  "severity": "info",                                                                                                                                       
  "time": "2024-07-29T16:44:50.502Z"                                                                                                                        
} 
```