### PR TITLE
Always return :ok even if nothing is logged

### DIFF
--- a/lib/logger_json/plug.ex
+++ b/lib/logger_json/plug.ex
@@ -83,6 +83,8 @@ if Code.ensure_loaded?(Plug) and Code.ensure_loaded?(:telemetry) do
           conn: conn,
           duration_μs: duration
         )
+      else
+        :ok
       end
     end
 

--- a/test/logger_json/plug_test.exs
+++ b/test/logger_json/plug_test.exs
@@ -593,5 +593,16 @@ defmodule LoggerJSON.PlugTest do
     end
   end
 
+  test "telemetry_logging_handler/4 returns :ok even when Logger is not called" do
+    log =
+      capture_log(fn ->
+        assert :ok == telemetry_logging_handler([], %{duration: 0}, %{conn: %Plug.Conn{}}, false)
+
+        Logger.flush()
+      end)
+
+    assert log == ""
+  end
+
   def ignore_log(%Plug.Conn{}, :arg), do: false
 end


### PR DESCRIPTION
Make the return type of `telemetry_logging_handler` conform to its spec.

Currently, if the `if level = level(level, conn)` condition fails, the function returns `nil`, not `:ok` as specified.