### PR TITLE
fix(elastic): encode duration_μs inserted by LoggerJSON.Plug as event.duration

### DIFF
--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -269,10 +269,12 @@ defmodule LoggerJSON.Formatters.Elastic do
         "http.request.referrer": LoggerJSON.Formatter.Plug.get_header(conn, "referer"),
         "http.response.status_code": conn.status,
         "url.path": conn.request_path,
-        "user_agent.original": LoggerJSON.Formatter.Plug.get_header(conn, "user-agent"),
-        "event.duration": duration_μs * 1000
+        "user_agent.original": LoggerJSON.Formatter.Plug.get_header(conn, "user-agent")
       }
+      |> maybe_put(:"event.duration", to_nanosecs(duration_μs))
     end
+
+    defp format_http_request(%{conn: %Plug.Conn{} = conn}), do: format_http_request(%{conn: conn, duration_μs: nil})
   end
 
   defp format_http_request(_meta), do: nil
@@ -290,4 +292,7 @@ defmodule LoggerJSON.Formatters.Elastic do
   end
 
   defp safe_chardata_to_string(other), do: other
+
+  defp to_nanosecs(duration) when is_number(duration), do: duration * 1000
+  defp to_nanosecs(_), do: nil
 end

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -260,7 +260,8 @@ defmodule LoggerJSON.Formatters.Elastic do
     # - http.*: https://www.elastic.co/guide/en/ecs/8.11/ecs-http.html
     # - url.path: https://www.elastic.co/guide/en/ecs/8.11/ecs-url.html
     # - user_agent.original: https://www.elastic.co/guide/en/ecs/8.11/ecs-user_agent.html
-    defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
+    # - event.duration (note: ns, not μs): https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-duration
+    defp format_http_request(%{conn: %Plug.Conn{} = conn, duration_μs: duration_μs}) do
       %{
         "client.ip": LoggerJSON.Formatter.Plug.remote_ip(conn),
         "http.version": Plug.Conn.get_http_protocol(conn),
@@ -268,7 +269,8 @@ defmodule LoggerJSON.Formatters.Elastic do
         "http.request.referrer": LoggerJSON.Formatter.Plug.get_header(conn, "referer"),
         "http.response.status_code": conn.status,
         "url.path": conn.request_path,
-        "user_agent.original": LoggerJSON.Formatter.Plug.get_header(conn, "user-agent")
+        "user_agent.original": LoggerJSON.Formatter.Plug.get_header(conn, "user-agent"),
+        "event.duration": duration_μs * 1000
       }
     end
   end

--- a/test/logger_json/formatters/elastic_test.exs
+++ b/test/logger_json/formatters/elastic_test.exs
@@ -368,7 +368,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
       |> Plug.Conn.put_req_header("x-forwarded-for", "")
       |> Plug.Conn.send_resp(200, "Hi!")
 
-    Logger.metadata(conn: conn)
+    Logger.metadata(conn: conn, duration_μs: 1337)
 
     log_entry =
       capture_log(fn ->
@@ -378,6 +378,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
 
     assert %{
              "client.ip" => "",
+             "event.duration" => 1_337_000,
              "http.version" => "HTTP/1.1",
              "http.request.method" => "GET",
              "http.request.referrer" => "http://www.example2.com/",


### PR DESCRIPTION
Hi. While trying out `LoggerJSON.Plug` I noticed that it adds `duration_μs` as metadata, but this is not a valid field in the Elastic Common Schema, so here's a quick fix to remap that to [`event.duration`](https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-duration) as is also recommended on the [Elastic forum](https://discuss.elastic.co/t/field-for-http-response-times/272742)

Note that similar changes might be necessary for the Google Cloud and Datadog formatters too.