### PR TITLE
Remap `duration_us` to spec-compliant fields for Elastic and DataDog formatters

### DIFF
--- a/test/logger_json/formatters/elastic_test.exs
+++ b/test/logger_json/formatters/elastic_test.exs
@@ -368,7 +368,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
       |> Plug.Conn.put_req_header("x-forwarded-for", "")
       |> Plug.Conn.send_resp(200, "Hi!")
 
-    Logger.metadata(conn: conn)
+    Logger.metadata(conn: conn, duration_us: 1337)
 
     log_entry =
       capture_log(fn ->
@@ -378,6 +378,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
 
     assert %{
              "client.ip" => "",
+             "event.duration" => 1_337_000,
              "http.version" => "HTTP/1.1",
              "http.request.method" => "GET",
              "http.request.referrer" => "http://www.example2.com/",


### PR DESCRIPTION
As mentioned in #124 

`duration_us` is not a valid field in the Elastic Common Schema (the [Elastic forum](https://discuss.elastic.co/t/field-for-http-response-times/272742) recommends using [event.duration](https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-duration)) and DataDog recommends using [`duration`](https://docs.datadoghq.com/standard-attributes/?search=duration&product=log+management), so this PR remaps that.