### PR TITLE
Handle Task/GenServer exits correctly in Google formatter

### DIFF
--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -188,9 +188,13 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
     format_reported_error_event(message, ruby_stacktrace, service_context, meta)
   end
 
-  def format_crash_reason(binary, {error, reason}, service_context, meta) do
+  def format_crash_reason(binary, {error, reason}, service_context, meta) when is_atom(error) or is_binary(error) do
     stacktrace = "** (#{error}) #{inspect(reason)}"
     format_reported_error_event(binary, stacktrace, service_context, meta)
+  end
+
+  def format_crash_reason(binary, {error, reason}, service_context, meta) do
+    format_crash_reason(binary, {inspect(error), reason}, service_context, meta)
   end
 
   defp format_reported_error_event(message, stacktrace, service_context, meta) do

--- a/test/support/crashing_gen_server.ex
+++ b/test/support/crashing_gen_server.ex
@@ -1,0 +1,15 @@
+defmodule CrashingGenServer do
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def handle_call(:boom, _, _) do
+    raise "boom"
+  end
+end


### PR DESCRIPTION
We were running into a situation where errors caused by GenServers terminating were not being formatted because they were a slightly different shape to what was expected in the formatter. This updates the formatter to handle them.

I'm very open to implementing and/or testing this in a different way - any/all feedback appreciated!