### PR TITLE
fix: check if Decimal is loaded in encoder

### DIFF
--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -36,7 +36,10 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode(%DateTime{} = datetime, _redactors), do: datetime
   def encode(%Date{} = date, _redactors), do: date
   def encode(%Time{} = time, _redactors), do: time
-  def encode(%Decimal{} = decimal, _redactors), do: decimal
+
+  if Code.ensure_loaded?(Decimal) do
+    def encode(%Decimal{} = decimal, _redactors), do: decimal
+  end
 
   def encode(%_struct{} = struct, redactors) do
     struct

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule LoggerJSON.Mixfile do
     [
       {:jason, "~> 1.4"},
       {:plug, "~> 1.15", optional: true},
+      {:decimal, ">= 0.0.0", optional: true},
       {:ecto, "~> 3.11", optional: true},
       {:telemetry, "~> 1.0", optional: true},
       {:stream_data, "~> 1.0", only: [:dev, :test]},


### PR DESCRIPTION
If Decimal is not included in the main app depending on LoggerJSON, the following line in `LoggerJSON.Formatter.RedactorEncoder` is not included:

```elixir
    def encode(%Decimal{} = decimal, _redactors), do: decimal
```