### PR TITLE
Include file, line and mfa in basic formatter metadata

### DIFF
--- a/lib/logger_json/formatter/metadata.ex
+++ b/lib/logger_json/formatter/metadata.ex
@@ -1,7 +1,7 @@
 defmodule LoggerJSON.Formatter.Metadata do
   @moduledoc false
 
-  @ignored_metadata_keys ~w[ansi_color initial_call crash_reason pid gl mfa report_cb time]a
+  @ignored_metadata_keys ~w[ansi_color initial_call crash_reason pid gl report_cb time]a
 
   @doc """
   Takes current metadata option value and updates it to exclude the given keys.

--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -64,6 +64,11 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode(list, redactors) when is_list(list), do: for(el <- list, do: encode(el, redactors))
   def encode(data, _redactors), do: inspect(data, pretty: true, width: 80)
 
+  defp encode_key_value({:mfa, {_module, _function, _arity} = mfa}, redactors) do
+    value = format_mfa(mfa)
+    encode_key_value({:mfa, value}, redactors)
+  end
+
   defp encode_key_value({key, value}, redactors) do
     key = encode_key(key)
     {key, encode(redact(key, value, redactors), redactors)}
@@ -72,6 +77,8 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   defp encode_key(key) when is_binary(key), do: encode_binary(key)
   defp encode_key(key) when is_atom(key) or is_number(key), do: key
   defp encode_key(key), do: inspect(key)
+
+  defp format_mfa({module, function, arity}), do: "#{module}.#{function}/#{arity}"
 
   defp encode_binary(data) when is_binary(data) do
     if String.valid?(data) && String.printable?(data) do

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -19,8 +19,7 @@ defmodule LoggerJSON.Formatters.Basic do
 
   @behaviour LoggerJSON.Formatter
 
-  @processed_metadata_keys ~w[file line mfa
-                              otel_span_id span_id
+  @processed_metadata_keys ~w[otel_span_id span_id
                               otel_trace_id trace_id
                               conn]a
 

--- a/test/logger_json/formatter/metadata_test.exs
+++ b/test/logger_json/formatter/metadata_test.exs
@@ -99,7 +99,6 @@ defmodule LoggerJSON.Formatter.MetadataTest do
         crash_reason: "crash_reason",
         pid: "pid",
         gl: "gl",
-        mfa: "mfa",
         report_cb: "report_cb",
         time: "time"
       }

--- a/test/logger_json/formatters/basic_test.exs
+++ b/test/logger_json/formatters/basic_test.exs
@@ -114,6 +114,20 @@ defmodule LoggerJSON.Formatters.BasicTest do
     assert log["trace"] == "294740ce41cc9f202dedb563db123532"
   end
 
+  test "logs file, line and mfa as metadata" do
+    metadata =
+      capture_log(fn ->
+        Logger.debug("Hello")
+      end)
+      |> decode_or_print_error()
+      |> Map.get("metadata")
+
+    assert metadata |> Map.get("file") |> to_string() =~ "logger_json/formatters/basic_test.exs"
+    assert metadata |> Map.get("line") |> is_integer()
+
+    assert metadata["mfa"] === "Elixir.LoggerJSON.Formatters.BasicTest.test logs file, line and mfa as metadata/1"
+  end
+
   test "logs metadata" do
     Logger.metadata(
       date: Date.utc_today(),


### PR DESCRIPTION
Include file, line and mfa in the basic formatter metadata.

Fixes #137 