### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
           - otp-version: 24.3
             elixir-version: 1.16
           - otp-version: 25
-            elixir-version: 1.15.1
-          - otp-version: 25
+            elixir-version: 1.15
+          - otp-version: 26
             elixir-version: 1.16
+          - otp-version: 27
+            elixir-version: 1.17
             check-formatted: true
             report-coverage: true
     steps:


### PR DESCRIPTION
Not sure exactly what the testing strategy is but:

* include elixir 1.17 & erlang 27
* run elixir 1.16 against erlang 26 as well to cover erlang 26
* since most versions seem to forego patch levels, remove that from elixir 1.15


Thanks for `logger_json` :green_heart: 