### PR TITLE
Reference full module name in config to enable copy & paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ config :logger, :default_handler,
 or during runtime:
 
 ```elixir
-:logger.update_handler_config(:default, :formatter, {Basic, %{metadata: {:all_except, [:conn]}}})
+:logger.update_handler_config(:default, :formatter, {LoggerJSON.Formatters.Basic, %{metadata: {:all_except, [:conn]}}})
 ```
 
 ## Docs


### PR DESCRIPTION
The previous version would crash once you do the first log as `Basic` without aliases is an unknown module.

For setup/configuration docs I think this is better, so people can easily copy & paste it :)

Thanks for `logger_json`!