### PR TITLE
add <formatter>.new/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Then, enable the formatter in your `config.exs`:
 
 ```elixir
 config :logger, :default_handler,
-  formatter: {LoggerJSON.Formatters.Basic, []}
+  formatter: LoggerJSON.Formatters.Basic.new(metadata: [:request_id])
 ```
 
 or during runtime (eg. in your `application.ex`):
 
 ```elixir
-:logger.update_handler_config(:default, :formatter, {Basic, []})
+formatter = LoggerJSON.Formatters.Basic.new(metadata: :all)
+:logger.update_handler_config(:default, :formatter, formatter)
 ```
 
 You might also want to format the log messages when migrations are running:
@@ -65,13 +66,14 @@ For example in `config.exs`:
 
 ```elixir
 config :logger, :default_handler,
-  formatter: {LoggerJSON.Formatters.GoogleCloud, metadata: :all, project_id: "logger-101"}
+  formatter: LoggerJSON.Formatters.GoogleCloud.new(metadata: :all, project_id: "logger-101")
 ```
 
 or during runtime:
 
 ```elixir
-:logger.update_handler_config(:default, :formatter, {LoggerJSON.Formatters.Basic, %{metadata: {:all_except, [:conn]}}})
+formatter = LoggerJSON.Formatters.Basic.new(%{metadata: {:all_except, [:conn]}})
+:logger.update_handler_config(:default, :formatter, formatter)
 ```
 
 ## Docs

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -34,11 +34,12 @@ defmodule LoggerJSON do
   Then, enable the formatter in your `config.exs`:
 
       config :logger, :default_handler,
-        formatter: {LoggerJSON.Formatters.Basic, []}
+        formatter: LoggerJSON.Formatters.Basic.new(metadata: :all)
 
   or during runtime (eg. in your `application.ex`):
 
-      :logger.update_handler_config(:default, :formatter, {Basic, %{}})
+      formatter = LoggerJSON.Formatters.Basic.new(metadata: :all)
+      :logger.update_handler_config(:default, :formatter, formatter)
 
   ## Configuration
 
@@ -46,11 +47,12 @@ defmodule LoggerJSON do
   For example in `config.exs`:
 
       config :logger, :default_handler,
-        formatter: {LoggerJSON.Formatters.GoogleCloud, metadata: :all, project_id: "logger-101"}
+        formatter: LoggerJSON.Formatters.GoogleCloud.new(metadata: :all, project_id: "logger-101")
 
   or during runtime:
 
-      :logger.update_handler_config(:default, :formatter, {Basic, %{metadata: {:all_except, [:conn]}}})
+      formatter = LoggerJSON.Formatters.Basic.new(metadata: {:all_except, [:conn]})
+      :logger.update_handler_config(:default, :formatter, formatter)
 
   ### Shared Options
 
@@ -81,7 +83,7 @@ defmodule LoggerJSON do
   Formatters may encode the well-known metadata differently and support additional metadata keys, see the documentation
   of the formatter for more details.
   """
-  @log_levels [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice]
+  @log_levels Logger.levels()
   @log_level_strings Enum.map(@log_levels, &to_string/1)
 
   @doc """
@@ -111,6 +113,6 @@ defmodule LoggerJSON do
     do: Logger.configure(level: level)
 
   def configure_log_level!(level) do
-    raise ArgumentError, "Log level should be one of 'debug', 'info', 'warn', 'error' values, got: #{inspect(level)}"
+    raise ArgumentError, "Log level should be one of #{inspect(@log_levels)} values, got: #{inspect(level)}"
   end
 end

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -83,7 +83,9 @@ defmodule LoggerJSON do
   Formatters may encode the well-known metadata differently and support additional metadata keys, see the documentation
   of the formatter for more details.
   """
-  @log_levels Logger.levels()
+
+  # TODO: replace with `Logger.levels()` once LoggerJSON starts depending on Elixir 1.16+
+  @log_levels [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice]
   @log_level_strings Enum.map(@log_levels, &to_string/1)
 
   @doc """

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -6,5 +6,6 @@ defmodule LoggerJSON.Formatter do
           | {atom(), term()}
         ]
 
-  @callback format(event :: :logger.log_event(), config :: term) :: iodata()
+  @callback new(opts) :: {module, :logger.formatter_config()}
+  @callback format(:logger.log_event(), :logger.formatter_config()) :: iodata()
 end

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -6,5 +6,5 @@ defmodule LoggerJSON.Formatter do
           | {atom(), term()}
         ]
 
-  @callback format(event :: :logger.log_event(), opts :: opts()) :: iodata()
+  @callback format(event :: :logger.log_event(), config :: term) :: iodata()
 end

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -24,13 +24,22 @@ defmodule LoggerJSON.Formatters.Basic do
                               otel_trace_id trace_id
                               conn]a
 
-  @impl true
-  def format(%{level: level, meta: meta, msg: msg}, opts) do
+  def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])
+    {__MODULE__, %{encoder_opts: encoder_opts, metadata: metadata_selector, redactors: redactors}}
+  end
+
+  @impl true
+  def format(%{level: level, meta: meta, msg: msg}, config) do
+    %{
+      encoder_opts: encoder_opts,
+      metadata: metadata_selector,
+      redactors: redactors
+    } = config
 
     message =
       format_message(msg, meta, %{

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -24,6 +24,7 @@ defmodule LoggerJSON.Formatters.Basic do
                               otel_trace_id trace_id
                               conn]a
 
+  @impl true
   def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -48,15 +48,24 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   @processed_metadata_keys ~w[pid file line mfa conn]a
 
-  @impl true
-  def format(%{level: level, meta: meta, msg: msg}, opts) do
+  def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])
     redactors = Keyword.get(opts, :redactors, [])
     hostname = Keyword.get(opts, :hostname, :system)
-
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
+    {__MODULE__, %{encoder_opts: encoder_opts, metadata: metadata_selector, redactors: redactors, hostname: hostname}}
+  end
+
+  @impl true
+  def format(%{level: level, meta: meta, msg: msg}, config) do
+    %{
+      encoder_opts: encoder_opts,
+      metadata: metadata_selector,
+      redactors: redactors,
+      hostname: hostname
+    } = config
 
     message =
       format_message(msg, meta, %{

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -48,6 +48,7 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   @processed_metadata_keys ~w[pid file line mfa conn]a
 
+  @impl true
   def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -141,6 +141,7 @@ defmodule LoggerJSON.Formatters.Elastic do
                               otel_trace_id trace_id
                               conn]a
 
+  @impl true
   def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -141,13 +141,22 @@ defmodule LoggerJSON.Formatters.Elastic do
                               otel_trace_id trace_id
                               conn]a
 
-  @impl LoggerJSON.Formatter
-  def format(%{level: level, meta: meta, msg: msg}, opts) do
+  def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])
+    {__MODULE__, %{encoder_opts: encoder_opts, metadata: metadata_selector, redactors: redactors}}
+  end
+
+  @impl LoggerJSON.Formatter
+  def format(%{level: level, meta: meta, msg: msg}, config) do
+    %{
+      encoder_opts: encoder_opts,
+      metadata: metadata_selector,
+      redactors: redactors
+    } = config
 
     message =
       format_message(msg, meta, %{

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -98,6 +98,7 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
                               otel_trace_id trace_id
                               conn]a
 
+  @impl true
   def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -98,8 +98,7 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
                               otel_trace_id trace_id
                               conn]a
 
-  @impl true
-  def format(%{level: level, meta: meta, msg: msg}, opts) do
+  def new(opts) do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get(opts, :encoder_opts, [])
     redactors = Keyword.get(opts, :redactors, [])
@@ -107,6 +106,26 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
     project_id = Keyword.get(opts, :project_id)
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
+
+    {__MODULE__,
+     %{
+       encoder_opts: encoder_opts,
+       redactors: redactors,
+       service_context: service_context,
+       project_id: project_id,
+       metadata: metadata_selector
+     }}
+  end
+
+  @impl true
+  def format(%{level: level, meta: meta, msg: msg}, config) do
+    %{
+      encoder_opts: encoder_opts,
+      redactors: redactors,
+      service_context: service_context,
+      project_id: project_id,
+      metadata: metadata_selector
+    } = config
 
     message =
       format_message(msg, meta, %{

--- a/lib/logger_json/redactors/redact_keys.ex
+++ b/lib/logger_json/redactors/redact_keys.ex
@@ -5,9 +5,12 @@ defmodule LoggerJSON.Redactors.RedactKeys do
   It takes list of keys to redact as an argument, eg.:
   ```elixir
   config :logger, :default_handler,
-    formatter: {LoggerJSON.Formatters.Basic, redactors: [
-      {LoggerJSON.Redactors.RedactKeys, ["password"]}
-    ]}
+    formatter:
+      LoggerJSON.Formatters.Basic.new(
+        redactors: [
+          {LoggerJSON.Redactors.RedactKeys, ["password"]}
+        ]
+      )
   ```
 
   Keep in mind that the key will be converted to binary before sending it to the redactor.

--- a/test/logger_json/ecto_test.exs
+++ b/test/logger_json/ecto_test.exs
@@ -4,7 +4,7 @@ defmodule LoggerJSON.EctoTest do
   require Logger
 
   setup do
-    formatter = {LoggerJSON.Formatters.Basic, metadata: :all}
+    formatter = LoggerJSON.Formatters.Basic.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
   end
 

--- a/test/logger_json/formatters/basic_test.exs
+++ b/test/logger_json/formatters/basic_test.exs
@@ -5,7 +5,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
   require Logger
 
   setup do
-    formatter = {Basic, metadata: :all}
+    formatter = Basic.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
   end
 
@@ -158,7 +158,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
              }
            } = log
 
-    formatter = {Basic, metadata: {:all_except, [:struct]}}
+    formatter = Basic.new(metadata: {:all_except, [:struct]})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     log =
@@ -181,7 +181,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
              }
            } = log
 
-    formatter = {Basic, metadata: [:node]}
+    formatter = Basic.new(metadata: [:node])
     :logger.update_handler_config(:default, :formatter, formatter)
 
     log =
@@ -243,7 +243,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
   end
 
   test "passing options to encoder" do
-    formatter = {Basic, encoder_opts: [pretty: true]}
+    formatter = Basic.new(encoder_opts: [pretty: true])
     :logger.update_handler_config(:default, :formatter, formatter)
 
     assert capture_log(fn ->
@@ -254,7 +254,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
 
   test "reads metadata from the given application env" do
     Application.put_env(:logger_json, :test_basic_metadata_key, [:foo])
-    formatter = {Basic, metadata: {:from_application_env, {:logger_json, :test_basic_metadata_key}}}
+    formatter = Basic.new(metadata: {:from_application_env, {:logger_json, :test_basic_metadata_key}})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")
@@ -274,7 +274,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
 
   test "reads metadata from the given application env at given path" do
     Application.put_env(:logger_json, :test_basic_metadata_key, metadata: [:foo])
-    formatter = {Basic, metadata: {:from_application_env, {:logger_json, :test_basic_metadata_key}, [:metadata]}}
+    formatter = Basic.new(metadata: {:from_application_env, {:logger_json, :test_basic_metadata_key}, [:metadata]})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")

--- a/test/logger_json/formatters/datadog_test.exs
+++ b/test/logger_json/formatters/datadog_test.exs
@@ -5,7 +5,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
   require Logger
 
   setup do
-    formatter = {Datadog, metadata: :all}
+    formatter = Datadog.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
   end
 
@@ -91,7 +91,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
     assert log["syslog"]["hostname"] == :inet.gethostname() |> elem(1) |> IO.chardata_to_string()
 
     # static value
-    formatter = {Datadog, hostname: "foo.bar1"}
+    formatter = Datadog.new(hostname: "foo.bar1")
     :logger.update_handler_config(:default, :formatter, formatter)
 
     log =
@@ -103,7 +103,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
     assert log["syslog"]["hostname"] == "foo.bar1"
 
     # unset value
-    formatter = {Datadog, hostname: :unset}
+    formatter = Datadog.new(hostname: :unset)
     :logger.update_handler_config(:default, :formatter, formatter)
 
     log =
@@ -456,7 +456,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
   end
 
   test "passing options to encoder" do
-    formatter = {Datadog, encoder_opts: [pretty: true]}
+    formatter = Datadog.new(encoder_opts: [pretty: true])
     :logger.update_handler_config(:default, :formatter, formatter)
 
     assert capture_log(fn ->
@@ -467,7 +467,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
 
   test "reads metadata from the given application env" do
     Application.put_env(:logger_json, :test_datadog_metadata_key, [:foo])
-    formatter = {Datadog, metadata: {:from_application_env, {:logger_json, :test_datadog_metadata_key}}}
+    formatter = Datadog.new(metadata: {:from_application_env, {:logger_json, :test_datadog_metadata_key}})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")
@@ -485,7 +485,7 @@ defmodule LoggerJSON.Formatters.DatadogTest do
 
   test "reads metadata from the given application env at given path" do
     Application.put_env(:logger_json, :test_datadog_metadata_key, metadata: [:foo])
-    formatter = {Datadog, metadata: {:from_application_env, {:logger_json, :test_datadog_metadata_key}, [:metadata]}}
+    formatter = Datadog.new(metadata: {:from_application_env, {:logger_json, :test_datadog_metadata_key}, [:metadata]})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")

--- a/test/logger_json/formatters/elastic_test.exs
+++ b/test/logger_json/formatters/elastic_test.exs
@@ -5,7 +5,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
   require Logger
 
   setup do
-    formatter = {Elastic, metadata: :all}
+    formatter = Elastic.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
   end
 
@@ -490,7 +490,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
   end
 
   test "passing options to encoder" do
-    formatter = {Elastic, encoder_opts: [pretty: true]}
+    formatter = Elastic.new(encoder_opts: [pretty: true])
     :logger.update_handler_config(:default, :formatter, formatter)
 
     assert capture_log(fn ->
@@ -501,7 +501,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
 
   test "reads metadata from the given application env" do
     Application.put_env(:logger_json, :test_elastic_metadata_key, [:foo])
-    formatter = {Elastic, metadata: {:from_application_env, {:logger_json, :test_elastic_metadata_key}}}
+    formatter = Elastic.new(metadata: {:from_application_env, {:logger_json, :test_elastic_metadata_key}})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")
@@ -519,7 +519,7 @@ defmodule LoggerJSON.Formatters.ElasticTest do
 
   test "reads metadata from the given application env at given path" do
     Application.put_env(:logger_json, :test_elastic_metadata_key, metadata: [:foo])
-    formatter = {Elastic, metadata: {:from_application_env, {:logger_json, :test_elastic_metadata_key}, [:metadata]}}
+    formatter = Elastic.new(metadata: {:from_application_env, {:logger_json, :test_elastic_metadata_key}, [:metadata]})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")

--- a/test/logger_json/formatters/google_cloud_test.exs
+++ b/test/logger_json/formatters/google_cloud_test.exs
@@ -5,7 +5,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
   require Logger
 
   setup do
-    formatter = {GoogleCloud, metadata: :all, project_id: "myproj-101"}
+    formatter = GoogleCloud.new(metadata: :all, project_id: "myproj-101")
     :logger.update_handler_config(:default, :formatter, formatter)
   end
 
@@ -117,7 +117,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
   end
 
   test "logs span and trace ids without project_id" do
-    formatter = {GoogleCloud, metadata: :all}
+    formatter = GoogleCloud.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(
@@ -169,7 +169,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
   end
 
   test "does not crash on invalid OTEL span and trace ids" do
-    formatter = {GoogleCloud, metadata: :all}
+    formatter = GoogleCloud.new(metadata: :all)
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(
@@ -531,7 +531,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
   end
 
   test "passing options to encoder" do
-    formatter = {GoogleCloud, encoder_opts: [pretty: true]}
+    formatter = GoogleCloud.new(encoder_opts: [pretty: true])
     :logger.update_handler_config(:default, :formatter, formatter)
 
     assert capture_log(fn ->
@@ -542,7 +542,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
 
   test "reads metadata from the given application env" do
     Application.put_env(:logger_json, :test_google_cloud_metadata_key, [:foo])
-    formatter = {GoogleCloud, metadata: {:from_application_env, {:logger_json, :test_google_cloud_metadata_key}}}
+    formatter = GoogleCloud.new(metadata: {:from_application_env, {:logger_json, :test_google_cloud_metadata_key}})
     :logger.update_handler_config(:default, :formatter, formatter)
 
     Logger.metadata(foo: "foo")
@@ -562,7 +562,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
     Application.put_env(:logger_json, :test_google_cloud_metadata_key, metadata: [:foo])
 
     formatter =
-      {GoogleCloud, metadata: {:from_application_env, {:logger_json, :test_google_cloud_metadata_key}, [:metadata]}}
+      GoogleCloud.new(metadata: {:from_application_env, {:logger_json, :test_google_cloud_metadata_key}, [:metadata]})
 
     :logger.update_handler_config(:default, :formatter, formatter)
 

--- a/test/logger_json/plug_test.exs
+++ b/test/logger_json/plug_test.exs
@@ -24,7 +24,7 @@ defmodule LoggerJSON.PlugTest do
 
   describe "telemetry_logging_handler/4 for Basic formatter" do
     setup do
-      formatter = {LoggerJSON.Formatters.Basic, metadata: :all}
+      formatter = LoggerJSON.Formatters.Basic.new(metadata: :all)
       :logger.update_handler_config(:default, :formatter, formatter)
     end
 
@@ -142,7 +142,7 @@ defmodule LoggerJSON.PlugTest do
 
   describe "telemetry_logging_handler/4 for DataDog formatter" do
     setup do
-      formatter = {LoggerJSON.Formatters.Datadog, metadata: [:network, :phoenix, :duration, :http, :"usr.id"]}
+      formatter = LoggerJSON.Formatters.Datadog.new(metadata: [:network, :phoenix, :duration, :http, :"usr.id"])
       :logger.update_handler_config(:default, :formatter, formatter)
     end
 
@@ -338,7 +338,7 @@ defmodule LoggerJSON.PlugTest do
 
   describe "telemetry_logging_handler/4 for GoogleCloud formatter" do
     setup do
-      formatter = {LoggerJSON.Formatters.GoogleCloud, metadata: {:all_except, [:conn]}}
+      formatter = LoggerJSON.Formatters.GoogleCloud.new(metadata: {:all_except, [:conn]})
       :logger.update_handler_config(:default, :formatter, formatter)
     end
 
@@ -474,7 +474,7 @@ defmodule LoggerJSON.PlugTest do
 
   describe "telemetry_logging_handler/4 for Elastic formatter" do
     setup do
-      formatter = {LoggerJSON.Formatters.Elastic, metadata: nil}
+      formatter = LoggerJSON.Formatters.Elastic.new(metadata: nil)
       :logger.update_handler_config(:default, :formatter, formatter)
     end
 

--- a/test/logger_json_test.exs
+++ b/test/logger_json_test.exs
@@ -22,7 +22,8 @@ defmodule LoggerJSONTest do
     end
 
     test "raises on invalid log level" do
-      message = "Log level should be one of 'debug', 'info', 'warn', 'error' values, got: :invalid"
+      message =
+        "Log level should be one of [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice] values, got: :invalid"
 
       assert_raise ArgumentError, message, fn ->
         LoggerJSON.configure_log_level!(:invalid)


### PR DESCRIPTION
👋 

This PR adds a utility function to create formatters. Similar to [`Logger.Formatter.new/1`](https://hexdocs.pm/logger/main/Logger.Formatter.html#new/1)

Some other ideas for this PR:
- duplicate docs for each `new/1` to make it easier to use, right now the users need to know that there is a "Shared options" section in the LoggerJSON moduledoc, and I think people are usually too lazy to look for it :)
- add warnings on invalid options passed to `new/1`
- extra type specs on `new/1`?