### PR TITLE
Allow the usage of JSON for Elixir 1.18+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
             elixir-version: 1.17
             check-formatted: true
             report-coverage: true
+          - otp-version: 27
+            elixir-version: 1.18
+            check-formatted: true
+            report-coverage: true
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ or during runtime:
 :logger.update_handler_config(:default, :formatter, {LoggerJSON.Formatters.Basic, %{metadata: {:all_except, [:conn]}}})
 ```
 
+It is possible to set during compile-time the JSON encoder:
+
+```elixir
+config :logger_json, encoder: Jason
+```
+
+For Elixir 1.18+, `JSON` is available and can be set as the encoder:
+
+```elixir
+config :logger_json, encoder: JSON
+```
+
+For retro-compatibility, `Jason` is the default encoder. Make sure to add it to the project
+dependencies if the encoder will not be changed.
+
 ## Docs
 
 The docs can be found at [https://hexdocs.pm/logger_json](https://hexdocs.pm/logger_json).

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,14 @@
 import Config
 
+encoder =
+  if Version.compare(System.version(), "1.18.0") == :lt do
+    Jason
+  else
+    JSON
+  end
+
+config :logger_json, encoder: encoder
+
 config :logger,
   handle_otp_reports: true,
   handle_sasl_reports: false

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -52,13 +52,25 @@ defmodule LoggerJSON do
 
       :logger.update_handler_config(:default, :formatter, {Basic, %{metadata: {:all_except, [:conn]}}})
 
+  It is possible to set during compile-time the JSON encoder:
+
+      config :logger_json, encoder: Jason
+
+  For Elixir 1.18+, `JSON` is available and can be set as the encoder:
+
+      config :logger_json, encoder: JSON
+
+  For retro-compatibility, `Jason` is the default encoder. Make sure to add it to the project
+  dependencies if the encoder will not be changed.
+
   ### Shared Options
 
   Some formatters require additional configuration options. Here are the options that are common for each formatter:
 
-    * `:encoder_opts` - options to be passed directly to the JSON encoder. This allows you to customize the behavior of the JSON
-    encoder. See the [documentation for Jason](https://hexdocs.pm/jason/Jason.html#encode/2-options) for available options. By
-    default, no options are passed to the encoder.
+    * `:encoder_opts` - options to be passed directly to the JSON encoder. This allows you to customize the behavior
+    of the JSON encoder. If the encoder is `JSON`, it defaults to `JSON.protocol_encode/2`. Otherwise, defaults to
+    empty keywords. See the [documentation for Jason](https://hexdocs.pm/jason/Jason.html#encode/2-options) for
+    available options for `Jason` encoder.
 
     * `:metadata` - a list of metadata keys to include in the log entry. By default, no metadata is included.
     If `:all`is given, all metadata is included. If `{:all_except, keys}` is given, all metadata except

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -27,10 +27,12 @@ defmodule LoggerJSON.Formatter do
   def encoder_protocol, do: @encoder_protocol
 
   @doc false
-  @spec require_jason_helpers :: Macro.t()
-  defmacro require_jason_helpers do
-    quote do
-      require Jason.Helpers
+  @spec with(module(), Macro.t()) :: Macro.t()
+  defmacro with(encoder, block) do
+    if @encoder == Macro.expand(encoder, __CALLER__) do
+      block[:do]
+    else
+      block[:else]
     end
   end
 end

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -25,4 +25,12 @@ defmodule LoggerJSON.Formatter do
   @doc false
   @spec encoder_protocol :: module()
   def encoder_protocol, do: @encoder_protocol
+
+  @doc false
+  @spec require_jason_helpers :: Macro.t()
+  defmacro require_jason_helpers do
+    quote do
+      require Jason.Helpers
+    end
+  end
 end

--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -1,10 +1,28 @@
 defmodule LoggerJSON.Formatter do
   @type opts :: [
-          {:encoder_opts, [Jason.encode_opt()]}
+          {:encoder_opts, encoder_opts()}
           | {:metadata, :all | {:all_except, [atom()]} | [atom()]}
           | {:redactors, [{module(), term()}]}
           | {atom(), term()}
         ]
 
+  @type encoder_opts :: JSON.encoder() | [Jason.encode_opt()] | term()
+
   @callback format(event :: :logger.log_event(), opts :: opts()) :: iodata()
+
+  @encoder Application.compile_env(:logger_json, :encoder, Jason)
+  @encoder_protocol Application.compile_env(:logger_json, :encoder_protocol) || Module.concat(@encoder, "Encoder")
+  @default_encoder_opts if(@encoder == JSON, do: &JSON.protocol_encode/2, else: [])
+
+  @doc false
+  @spec default_encoder_opts :: encoder_opts()
+  def default_encoder_opts, do: @default_encoder_opts
+
+  @doc false
+  @spec encoder :: module()
+  def encoder, do: @encoder
+
+  @doc false
+  @spec encoder_protocol :: module()
+  def encoder_protocol, do: @encoder_protocol
 end

--- a/lib/logger_json/formatter/redactor_encoder.ex
+++ b/lib/logger_json/formatter/redactor_encoder.ex
@@ -35,7 +35,7 @@ defmodule LoggerJSON.Formatter.RedactorEncoder do
   def encode(binary, _redactors) when is_binary(binary), do: encode_binary(binary)
 
   if @encoder_protocol == Jason.Encoder do
-    def encode(%Jason.Fragment{} = fragment, _redactors), do: fragment
+    def encode(fragment, _redactors) when is_struct(fragment, Jason.Fragment), do: fragment
   end
 
   def encode(%NaiveDateTime{} = naive_datetime, _redactors), do: naive_datetime

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -76,10 +76,10 @@ defmodule LoggerJSON.Formatters.Basic do
   end
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason do
-      defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
-        require Jason.Helpers
+    if @encoder == Jason and Code.ensure_loaded?(Jason) do
+      require Jason.Helpers
 
+      defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
         Jason.Helpers.json_map(
           connection:
             Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -76,8 +76,8 @@ defmodule LoggerJSON.Formatters.Basic do
   end
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason do
-      Formatter.require_jason_helpers()
+    Formatter.with Jason do
+      require Jason.Helpers
 
       defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
         Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -15,7 +15,7 @@ defmodule LoggerJSON.Formatters.Basic do
       }
   """
   import LoggerJSON.Formatter.{MapBuilder, DateTime, Message, Metadata, RedactorEncoder}
-  alias LoggerJSON.Formatter
+  require LoggerJSON.Formatter, as: Formatter
 
   @behaviour Formatter
 
@@ -76,8 +76,8 @@ defmodule LoggerJSON.Formatters.Basic do
   end
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason and Code.ensure_loaded?(Jason) do
-      require Jason.Helpers
+    if @encoder == Jason do
+      Formatter.require_jason_helpers()
 
       defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
         Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -77,9 +77,9 @@ defmodule LoggerJSON.Formatters.Basic do
 
   if Code.ensure_loaded?(Plug.Conn) do
     if @encoder == Jason do
-      require Jason.Helpers
-
       defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
+        require Jason.Helpers
+
         Jason.Helpers.json_map(
           connection:
             Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -15,19 +15,21 @@ defmodule LoggerJSON.Formatters.Basic do
       }
   """
   import LoggerJSON.Formatter.{MapBuilder, DateTime, Message, Metadata, RedactorEncoder}
-  require Jason.Helpers
+  alias LoggerJSON.Formatter
 
-  @behaviour LoggerJSON.Formatter
+  @behaviour Formatter
+
+  @encoder Formatter.encoder()
 
   @processed_metadata_keys ~w[file line mfa
                               otel_span_id span_id
                               otel_trace_id trace_id
                               conn]a
 
-  @impl true
+  @impl Formatter
   def format(%{level: level, meta: meta, msg: msg}, opts) do
     opts = Keyword.new(opts)
-    encoder_opts = Keyword.get(opts, :encoder_opts, [])
+    encoder_opts = Keyword.get_lazy(opts, :encoder_opts, &Formatter.default_encoder_opts/0)
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])
@@ -49,7 +51,7 @@ defmodule LoggerJSON.Formatters.Basic do
       |> maybe_put(:request, format_http_request(meta))
       |> maybe_put(:span, format_span(meta))
       |> maybe_put(:trace, format_trace(meta))
-      |> Jason.encode_to_iodata!(encoder_opts)
+      |> @encoder.encode_to_iodata!(encoder_opts)
 
     [line, "\n"]
   end
@@ -74,21 +76,40 @@ defmodule LoggerJSON.Formatters.Basic do
   end
 
   if Code.ensure_loaded?(Plug.Conn) do
-    defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
-      Jason.Helpers.json_map(
-        connection:
-          Jason.Helpers.json_map(
+    if @encoder == Jason do
+      require Jason.Helpers
+
+      defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
+        Jason.Helpers.json_map(
+          connection:
+            Jason.Helpers.json_map(
+              protocol: Plug.Conn.get_http_protocol(conn),
+              method: conn.method,
+              path: conn.request_path,
+              status: conn.status
+            ),
+          client:
+            Jason.Helpers.json_map(
+              user_agent: Formatter.Plug.get_header(conn, "user-agent"),
+              ip: Formatter.Plug.remote_ip(conn)
+            )
+        )
+      end
+    else
+      defp format_http_request(%{conn: %Plug.Conn{} = conn}) do
+        %{
+          connection: %{
             protocol: Plug.Conn.get_http_protocol(conn),
             method: conn.method,
             path: conn.request_path,
             status: conn.status
-          ),
-        client:
-          Jason.Helpers.json_map(
-            user_agent: LoggerJSON.Formatter.Plug.get_header(conn, "user-agent"),
-            ip: LoggerJSON.Formatter.Plug.remote_ip(conn)
-          )
-      )
+          },
+          client: %{
+            user_agent: Formatter.Plug.get_header(conn, "user-agent"),
+            ip: Formatter.Plug.remote_ip(conn)
+          }
+        }
+      end
     end
   end
 

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -211,8 +211,8 @@ defmodule LoggerJSON.Formatters.Datadog do
   defp format_http_request(_meta), do: nil
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason do
-      Formatter.require_jason_helpers()
+    Formatter.with Jason do
+      require Jason.Helpers
 
       defp build_http_request_data(%Plug.Conn{} = conn, request_id) do
         request_url = Plug.Conn.request_url(conn)

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -212,9 +212,9 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   if Code.ensure_loaded?(Plug.Conn) do
     if @encoder == Jason do
-      require Jason.Helpers
-
       defp build_http_request_data(%Plug.Conn{} = conn, request_id) do
+        require Jason.Helpers
+
         request_url = Plug.Conn.request_url(conn)
         user_agent = Formatter.Plug.get_header(conn, "user-agent")
         remote_ip = Formatter.Plug.remote_ip(conn)

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -206,9 +206,11 @@ defmodule LoggerJSON.Formatters.Datadog do
     end
 
     defp format_http_request(%{conn: %Plug.Conn{} = conn}), do: format_http_request(%{conn: conn, duration_us: nil})
+  end
 
-    defp format_http_request(_meta), do: nil
+  defp format_http_request(_meta), do: nil
 
+  if Code.ensure_loaded?(Plug.Conn) do
     if @encoder == Jason do
       require Jason.Helpers
 

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -270,6 +270,8 @@ defmodule LoggerJSON.Formatters.Datadog do
     end
   end
 
-  defp to_nanosecs(duration_us) when is_number(duration_us), do: duration_us * 1000
-  defp to_nanosecs(_), do: nil
+  if Code.ensure_loaded?(Plug.Conn) do
+    defp to_nanosecs(duration_us) when is_number(duration_us), do: duration_us * 1000
+    defp to_nanosecs(_), do: nil
+  end
 end

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -42,7 +42,7 @@ defmodule LoggerJSON.Formatters.Datadog do
       }
   """
   import LoggerJSON.Formatter.{MapBuilder, DateTime, Message, Metadata, Code, RedactorEncoder}
-  alias LoggerJSON.Formatter
+  require LoggerJSON.Formatter, as: Formatter
 
   @behaviour Formatter
 
@@ -211,8 +211,8 @@ defmodule LoggerJSON.Formatters.Datadog do
   defp format_http_request(_meta), do: nil
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason and Code.ensure_loaded?(Jason) do
-      require Jason.Helpers
+    if @encoder == Jason do
+      Formatter.require_jason_helpers()
 
       defp build_http_request_data(%Plug.Conn{} = conn, request_id) do
         request_url = Plug.Conn.request_url(conn)

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -211,10 +211,10 @@ defmodule LoggerJSON.Formatters.Datadog do
   defp format_http_request(_meta), do: nil
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason do
-      defp build_http_request_data(%Plug.Conn{} = conn, request_id) do
-        require Jason.Helpers
+    if @encoder == Jason and Code.ensure_loaded?(Jason) do
+      require Jason.Helpers
 
+      defp build_http_request_data(%Plug.Conn{} = conn, request_id) do
         request_url = Plug.Conn.request_url(conn)
         user_agent = Formatter.Plug.get_header(conn, "user-agent")
         remote_ip = Formatter.Plug.remote_ip(conn)

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -313,6 +313,8 @@ defmodule LoggerJSON.Formatters.Elastic do
 
   defp safe_chardata_to_string(other), do: other
 
-  defp to_nanosecs(duration_us) when is_number(duration_us), do: duration_us * 1000
-  defp to_nanosecs(_), do: nil
+  if Code.ensure_loaded?(Plug.Conn) do
+    defp to_nanosecs(duration_us) when is_number(duration_us), do: duration_us * 1000
+    defp to_nanosecs(_), do: nil
+  end
 end

--- a/lib/logger_json/formatters/elastic.ex
+++ b/lib/logger_json/formatters/elastic.ex
@@ -130,21 +130,23 @@ defmodule LoggerJSON.Formatters.Elastic do
 
   """
   import LoggerJSON.Formatter.{MapBuilder, DateTime, Message, Metadata, RedactorEncoder}
-  require Jason.Helpers
+  alias LoggerJSON.Formatter
 
-  @behaviour LoggerJSON.Formatter
+  @behaviour Formatter
 
   @ecs_version "8.11.0"
+
+  @encoder Formatter.encoder()
 
   @processed_metadata_keys ~w[file line mfa domain error_logger
                               otel_span_id span_id
                               otel_trace_id trace_id
                               conn]a
 
-  @impl LoggerJSON.Formatter
+  @impl Formatter
   def format(%{level: level, meta: meta, msg: msg}, opts) do
     opts = Keyword.new(opts)
-    encoder_opts = Keyword.get(opts, :encoder_opts, [])
+    encoder_opts = Keyword.get_lazy(opts, :encoder_opts, &Formatter.default_encoder_opts/0)
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     redactors = Keyword.get(opts, :redactors, [])
@@ -168,7 +170,7 @@ defmodule LoggerJSON.Formatters.Elastic do
       |> maybe_merge(format_http_request(meta))
       |> maybe_put(:"span.id", format_span_id(meta))
       |> maybe_put(:"trace.id", format_trace_id(meta))
-      |> Jason.encode_to_iodata!(encoder_opts)
+      |> @encoder.encode_to_iodata!(encoder_opts)
 
     [line, "\n"]
   end
@@ -281,13 +283,13 @@ defmodule LoggerJSON.Formatters.Elastic do
     # - event.duration (note: ns, not μs): https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-duration
     defp format_http_request(%{conn: %Plug.Conn{} = conn, duration_us: duration_us}) do
       %{
-        "client.ip": LoggerJSON.Formatter.Plug.remote_ip(conn),
+        "client.ip": Formatter.Plug.remote_ip(conn),
         "http.version": Plug.Conn.get_http_protocol(conn),
         "http.request.method": conn.method,
-        "http.request.referrer": LoggerJSON.Formatter.Plug.get_header(conn, "referer"),
+        "http.request.referrer": Formatter.Plug.get_header(conn, "referer"),
         "http.response.status_code": conn.status,
         "url.path": conn.request_path,
-        "user_agent.original": LoggerJSON.Formatter.Plug.get_header(conn, "user-agent")
+        "user_agent.original": Formatter.Plug.get_header(conn, "user-agent")
       }
       |> maybe_put(:"event.duration", to_nanosecs(duration_us))
     end

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -244,9 +244,9 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
 
   if Code.ensure_loaded?(Plug.Conn) do
     if @encoder == Jason do
-      require Jason.Helpers
-
       defp format_http_request(%{conn: %Plug.Conn{} = conn} = assigns) do
+        require Jason.Helpers
+
         request_method = conn.method |> to_string() |> String.upcase()
         request_url = Plug.Conn.request_url(conn)
         status = conn.status

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -89,7 +89,7 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
       }
   """
   import LoggerJSON.Formatter.{MapBuilder, DateTime, Message, Metadata, Code, RedactorEncoder}
-  alias LoggerJSON.Formatter
+  require LoggerJSON.Formatter, as: Formatter
 
   @behaviour Formatter
 
@@ -243,8 +243,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   defp format_crash_report_location(_meta), do: nil
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason and Code.ensure_loaded?(Jason) do
-      require Jason.Helpers
+    if @encoder == Jason do
+      Formatter.require_jason_helpers()
 
       defp format_http_request(%{conn: %Plug.Conn{} = conn} = assigns) do
         request_method = conn.method |> to_string() |> String.upcase()
@@ -352,8 +352,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   # coveralls-ignore-stop
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntryOperation
-  if @encoder == Jason and Code.ensure_loaded?(Jason) do
-    require Jason.Helpers
+  if @encoder == Jason do
+    Formatter.require_jason_helpers()
 
     defp format_operation(%{request_id: request_id, pid: pid}),
       do: Jason.Helpers.json_map(id: request_id, producer: inspect(pid))
@@ -369,8 +369,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   defp format_operation(_meta), do: nil
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
-  if @encoder == Jason and Code.ensure_loaded?(Jason) do
-    require Jason.Helpers
+  if @encoder == Jason do
+    Formatter.require_jason_helpers()
 
     defp format_source_location(%{file: file, line: line, mfa: {m, f, a}}) do
       Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -243,9 +243,7 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   defp format_crash_report_location(_meta), do: nil
 
   if Code.ensure_loaded?(Plug.Conn) do
-    if @encoder == Jason do
-      Formatter.require_jason_helpers()
-
+    Formatter.with Jason do
       defp format_http_request(%{conn: %Plug.Conn{} = conn} = assigns) do
         request_method = conn.method |> to_string() |> String.upcase()
         request_url = Plug.Conn.request_url(conn)
@@ -352,8 +350,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   # coveralls-ignore-stop
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntryOperation
-  if @encoder == Jason do
-    Formatter.require_jason_helpers()
+  Formatter.with Jason do
+    require Jason.Helpers
 
     defp format_operation(%{request_id: request_id, pid: pid}),
       do: Jason.Helpers.json_map(id: request_id, producer: inspect(pid))
@@ -369,8 +367,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
   defp format_operation(_meta), do: nil
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
-  if @encoder == Jason do
-    Formatter.require_jason_helpers()
+  Formatter.with Jason do
+    require Jason.Helpers
 
     defp format_source_location(%{file: file, line: line, mfa: {m, f, a}}) do
       Jason.Helpers.json_map(

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -353,26 +353,29 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntryOperation
   if @encoder == Jason do
-    require Jason.Helpers
+    defp operation(meta) do
+      require Jason.Helpers
 
-    defp format_operation(%{request_id: request_id, pid: pid}),
-      do: Jason.Helpers.json_map(id: request_id, producer: inspect(pid))
-
-    defp format_operation(%{pid: pid}), do: Jason.Helpers.json_map(producer: inspect(pid))
+      case meta do
+        %{request_id: request_id, pid: pid} -> Jason.Helpers.json_map(id: request_id, producer: inspect(pid))
+        %{pid: pid} -> Jason.Helpers.json_map(producer: inspect(pid))
+        _meta -> nil
+      end
+    end
   else
     defp format_operation(%{request_id: request_id, pid: pid}), do: %{id: request_id, producer: inspect(pid)}
     defp format_operation(%{pid: pid}), do: %{producer: inspect(pid)}
-  end
 
-  # Erlang logger always has `pid` in the metadata but we keep this clause "just in case"
-  # coveralls-ignore-next-line
-  defp format_operation(_meta), do: nil
+    # Erlang logger always has `pid` in the metadata but we keep this clause "just in case"
+    # coveralls-ignore-next-line
+    defp format_operation(_meta), do: nil
+  end
 
   # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
   if @encoder == Jason do
-    require Jason.Helpers
-
     defp format_source_location(%{file: file, line: line, mfa: {m, f, a}}) do
+      require Jason.Helpers
+
       Jason.Helpers.json_map(
         file: IO.chardata_to_string(file),
         line: line,

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -292,13 +292,15 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
 
   defp format_http_request(_meta), do: nil
 
-  defp http_request_latency(%{duration_us: duration_us}) do
-    duration_s = Float.round(duration_us / 1_000_000, 9)
-    "#{duration_s}s"
-  end
+  if Code.ensure_loaded?(Plug.Conn) do
+    defp http_request_latency(%{duration_us: duration_us}) do
+      duration_s = Float.round(duration_us / 1_000_000, 9)
+      "#{duration_s}s"
+    end
 
-  defp http_request_latency(_assigns) do
-    nil
+    defp http_request_latency(_assigns) do
+      nil
+    end
   end
 
   defp format_affected_user(%{user_id: user_id}), do: "user:" <> user_id

--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -244,6 +244,8 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
 
   if Code.ensure_loaded?(Plug.Conn) do
     Formatter.with Jason do
+      require Jason.Helpers
+
       defp format_http_request(%{conn: %Plug.Conn{} = conn} = assigns) do
         request_method = conn.method |> to_string() |> String.upcase()
         request_url = Plug.Conn.request_url(conn)

--- a/lib/logger_json/redactor.ex
+++ b/lib/logger_json/redactor.ex
@@ -2,8 +2,8 @@ defmodule LoggerJSON.Redactor do
   @moduledoc """
   This module provides a behaviour which allows to redact sensitive information from logs.
 
-  *Note*: redactor will not be applied on `Jason.Fragment` structs. For more information
-  about encoding and redacting see `LoggerJSON.Formatter.RedactorEncoder.encode/2`.
+  *Note*: redactor will not be applied on `Jason.Fragment` structs if the encoder is `Jason`.
+  For more information about encoding and redacting see `LoggerJSON.Formatter.RedactorEncoder.encode/2`.
   """
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule LoggerJSON.Mixfile do
 
   defp deps do
     [
-      {:jason, "~> 1.4"},
+      {:jason, "~> 1.4", optional: true},
       {:plug, "~> 1.15", optional: true},
       {:decimal, ">= 0.0.0", optional: true},
       {:ecto, "~> 3.11", optional: true},

--- a/test/logger_json/formatter_test.exs
+++ b/test/logger_json/formatter_test.exs
@@ -1,0 +1,25 @@
+defmodule LoggerJSON.FormatterTest do
+  use LoggerJSON.Case, async: true
+
+  @encoder Application.compile_env!(:logger_json, :encoder)
+  @encoder_protocol Module.concat(@encoder, "Encoder")
+  @default_encoder_opts if(@encoder == JSON, do: &JSON.protocol_encode/2, else: [])
+
+  describe "default_encoder_opts/0" do
+    test "returns value based on :encoder env" do
+      assert LoggerJSON.Formatter.default_encoder_opts() == @default_encoder_opts
+    end
+  end
+
+  describe "encoder/0" do
+    test "returns value based on :encoder env" do
+      assert LoggerJSON.Formatter.encoder() == @encoder
+    end
+  end
+
+  describe "encoder_protocol/0" do
+    test "returns value based on :encoder env" do
+      assert LoggerJSON.Formatter.encoder_protocol() == @encoder_protocol
+    end
+  end
+end

--- a/test/logger_json/formatter_test.exs
+++ b/test/logger_json/formatter_test.exs
@@ -1,6 +1,8 @@
 defmodule LoggerJSON.FormatterTest do
   use LoggerJSON.Case, async: true
 
+  require LoggerJSON.Formatter
+
   @encoder Application.compile_env!(:logger_json, :encoder)
   @encoder_protocol Module.concat(@encoder, "Encoder")
   @default_encoder_opts if(@encoder == JSON, do: &JSON.protocol_encode/2, else: [])
@@ -20,6 +22,38 @@ defmodule LoggerJSON.FormatterTest do
   describe "encoder_protocol/0" do
     test "returns value based on :encoder env" do
       assert LoggerJSON.Formatter.encoder_protocol() == @encoder_protocol
+    end
+  end
+
+  describe "with/2" do
+    test "runs do block if it matches encoder" do
+      result =
+        LoggerJSON.Formatter.with @encoder do
+          quote do
+            :ok
+          end
+        else
+          quote do
+            :error
+          end
+        end
+
+      assert result == :ok
+    end
+
+    test "runs else block if it does not match encoder" do
+      result =
+        LoggerJSON.Formatter.with Something do
+          quote do
+            :error
+          end
+        else
+          quote do
+            :ok
+          end
+        end
+
+      assert result == :ok
     end
   end
 end

--- a/test/logger_json/formatters/basic_test.exs
+++ b/test/logger_json/formatters/basic_test.exs
@@ -4,6 +4,8 @@ defmodule LoggerJSON.Formatters.BasicTest do
   alias LoggerJSON.Formatters.Basic
   require Logger
 
+  @encoder LoggerJSON.Formatter.encoder()
+
   setup do
     formatter = {Basic, metadata: :all}
     :logger.update_handler_config(:default, :formatter, formatter)
@@ -242,14 +244,16 @@ defmodule LoggerJSON.Formatters.BasicTest do
            }
   end
 
-  test "passing options to encoder" do
-    formatter = {Basic, encoder_opts: [pretty: true]}
-    :logger.update_handler_config(:default, :formatter, formatter)
+  if @encoder == Jason do
+    test "passing options to encoder" do
+      formatter = {Basic, encoder_opts: [pretty: true]}
+      :logger.update_handler_config(:default, :formatter, formatter)
 
-    assert capture_log(fn ->
-             Logger.debug("Hello")
-           end) =~
-             ~r/\n\s{2}"message": "Hello"/
+      assert capture_log(fn ->
+               Logger.debug("Hello")
+             end) =~
+               ~r/\n\s{2}"message": "Hello"/
+    end
   end
 
   test "reads metadata from the given application env" do

--- a/test/logger_json/formatters/datadog_test.exs
+++ b/test/logger_json/formatters/datadog_test.exs
@@ -4,6 +4,8 @@ defmodule LoggerJSON.Formatters.DatadogTest do
   alias LoggerJSON.Formatters.Datadog
   require Logger
 
+  @encoder LoggerJSON.Formatter.encoder()
+
   setup do
     formatter = {Datadog, metadata: :all}
     :logger.update_handler_config(:default, :formatter, formatter)
@@ -455,14 +457,16 @@ defmodule LoggerJSON.Formatters.DatadogTest do
            } = log_entry
   end
 
-  test "passing options to encoder" do
-    formatter = {Datadog, encoder_opts: [pretty: true]}
-    :logger.update_handler_config(:default, :formatter, formatter)
+  if @encoder == Jason do
+    test "passing options to encoder" do
+      formatter = {Datadog, encoder_opts: [pretty: true]}
+      :logger.update_handler_config(:default, :formatter, formatter)
 
-    assert capture_log(fn ->
-             Logger.debug("Hello")
-           end) =~
-             ~r/\n\s{2}"message": "Hello"/
+      assert capture_log(fn ->
+               Logger.debug("Hello")
+             end) =~
+               ~r/\n\s{2}"message": "Hello"/
+    end
   end
 
   test "reads metadata from the given application env" do

--- a/test/logger_json/formatters/elastic_test.exs
+++ b/test/logger_json/formatters/elastic_test.exs
@@ -4,6 +4,8 @@ defmodule LoggerJSON.Formatters.ElasticTest do
   alias LoggerJSON.Formatters.Elastic
   require Logger
 
+  @encoder LoggerJSON.Formatter.encoder()
+
   setup do
     formatter = {Elastic, metadata: :all}
     :logger.update_handler_config(:default, :formatter, formatter)
@@ -489,14 +491,16 @@ defmodule LoggerJSON.Formatters.ElasticTest do
     assert message =~ ~r/Task #PID<\d+.\d+.\d+> started from #{inspect(test_pid)} terminating/
   end
 
-  test "passing options to encoder" do
-    formatter = {Elastic, encoder_opts: [pretty: true]}
-    :logger.update_handler_config(:default, :formatter, formatter)
+  if @encoder == Jason do
+    test "passing options to encoder" do
+      formatter = {Elastic, encoder_opts: [pretty: true]}
+      :logger.update_handler_config(:default, :formatter, formatter)
 
-    assert capture_log(fn ->
-             Logger.debug("Hello")
-           end) =~
-             ~r/\n\s{2}"message": "Hello"/
+      assert capture_log(fn ->
+               Logger.debug("Hello")
+             end) =~
+               ~r/\n\s{2}"message": "Hello"/
+    end
   end
 
   test "reads metadata from the given application env" do

--- a/test/logger_json/formatters/google_cloud_test.exs
+++ b/test/logger_json/formatters/google_cloud_test.exs
@@ -4,6 +4,8 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
   alias LoggerJSON.Formatters.GoogleCloud
   require Logger
 
+  @encoder LoggerJSON.Formatter.encoder()
+
   setup do
     formatter = {GoogleCloud, metadata: :all, project_id: "myproj-101"}
     :logger.update_handler_config(:default, :formatter, formatter)
@@ -14,7 +16,7 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
       assert capture_log(fn ->
                Logger.debug(message)
              end)
-             |> Jason.decode!()
+             |> @encoder.decode!()
     end
   end
 
@@ -23,14 +25,14 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
       assert capture_log(fn ->
                Logger.debug(message)
              end)
-             |> Jason.decode!()
+             |> @encoder.decode!()
     end
 
     check all message <- StreamData.keyword_of(StreamData.term()) do
       assert capture_log(fn ->
                Logger.debug(message)
              end)
-             |> Jason.decode!()
+             |> @encoder.decode!()
     end
   end
 
@@ -530,14 +532,16 @@ defmodule LoggerJSON.Formatters.GoogleCloudTest do
            } = log_entry
   end
 
-  test "passing options to encoder" do
-    formatter = {GoogleCloud, encoder_opts: [pretty: true]}
-    :logger.update_handler_config(:default, :formatter, formatter)
+  if @encoder == Jason do
+    test "passing options to encoder" do
+      formatter = {GoogleCloud, encoder_opts: [pretty: true]}
+      :logger.update_handler_config(:default, :formatter, formatter)
 
-    assert capture_log(fn ->
-             Logger.debug("Hello")
-           end) =~
-             ~r/\n\s{2}"message": "Hello"/
+      assert capture_log(fn ->
+               Logger.debug("Hello")
+             end) =~
+               ~r/\n\s{2}"message": "Hello"/
+    end
   end
 
   test "reads metadata from the given application env" do

--- a/test/support/logger_case.ex
+++ b/test/support/logger_case.ex
@@ -3,6 +3,8 @@ defmodule LoggerJSON.Case do
   use ExUnit.CaseTemplate
   import ExUnit.CaptureIO
 
+  @encoder LoggerJSON.Formatter.encoder()
+
   using _ do
     quote do
       import LoggerJSON.Case
@@ -22,7 +24,7 @@ defmodule LoggerJSON.Case do
 
   def decode_or_print_error(data) do
     try do
-      Jason.decode!(data)
+      @encoder.decode!(data)
     rescue
       _reason ->
         IO.puts(data)

--- a/test/support/name_struct.ex
+++ b/test/support/name_struct.ex
@@ -6,6 +6,7 @@ defmodule NameStruct do
   are not compiled with the application so not protocol consolidation would happen.
   """
 
-  @derive Jason.Encoder
+  @derive LoggerJSON.Formatter.encoder_protocol()
+
   defstruct [:name]
 end


### PR DESCRIPTION
This PR preserves the current `Jason` encoder usage while allowing the custom configuration of the [JSON](https://hexdocs.pm/elixir/JSON.html) encoder for Elixir 1.18+.

Both setups are set to be tested by the CI: If the Elixir version is less than 1.18, it will test with `Jason`. Otherwise, it will test with `JSON`.