### PR TITLE
Fix Datadog's formatter crash on GenServer exit

### DIFF
--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -111,7 +111,7 @@ defmodule LoggerJSON.Formatters.Datadog do
   def format_crash_reason(binary, _other, _meta) do
     %{
       error: %{
-        message: binary
+        message: IO.chardata_to_string(binary)
       }
     }
   end


### PR DESCRIPTION
At the moment when `GenServer` exits, the `LoggerJSON.Formatters.Datadog` formatter crashes when trying to encode the message, because it can't handle the chardata.

This PR adds conversion in the `format_crash_reason` that doesn't have it yet and a corresponding test (based on `GoogleCloud` one).