### PR TITLE
Handle improper lists in RedactorEncoder

### DIFF
--- a/test/logger_json/formatter/redactor_encoder_test.exs
+++ b/test/logger_json/formatter/redactor_encoder_test.exs
@@ -77,6 +77,10 @@ defmodule LoggerJSON.Formatter.RedactorEncoderTest do
       assert encode([password: "foo"], @redactors) == %{password: "[REDACTED]"}
     end
 
+    test "redacts values in improper list tail" do
+      assert encode([nil | %{password: "foo"}], @redactors) == "[nil | %{password: \"[REDACTED]\"}]"
+    end
+
     test "converts non-string map keys" do
       assert encode(%{1 => 2}, []) == %{1 => 2}
       assert encode(%{:a => 1}, []) == %{:a => 1}
@@ -95,6 +99,18 @@ defmodule LoggerJSON.Formatter.RedactorEncoderTest do
 
     test "inspects pids" do
       assert encode(self(), []) == inspect(self())
+    end
+
+    test "inspects improper lists" do
+      assert encode([1, [2, 3], 4 | 5], @redactors) == "[1, [2, 3], 4 | 5]"
+    end
+
+    test "inspects improper lists that start as keyword lists" do
+      assert encode([{:foo, 1}, 2 | 3], @redactors) == "[[:foo, 1], 2 | 3]"
+    end
+
+    test "inspects improper keyword lists" do
+      assert encode([{:foo, 1} | {:bar, 2}], @redactors) == "[[:foo, 1] | {:bar, 2}]"
     end
 
     test "doesn't choke on things that look like keyword lists but aren't" do


### PR DESCRIPTION
Hi 👋 

Currently, `RedactorEncoder` can't handle an improper list and would crash a formatter:

```
iex(1)> LoggerJSON.Formatter.RedactorEncoder.encode([1 | 2], [])
** (FunctionClauseError) no function clause matching in Enum."-map/2-lists^map/1-1-"/2

    The following arguments were given to Enum."-map/2-lists^map/1-1-"/2:

        # 1
        #Function<3.49609762/1 in LoggerJSON.Formatter.RedactorEncoder.encode/2>

        # 2
        2

    (elixir 1.18.2) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.18.2) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    iex:1: (file)
```

This PR attempts to fix it. There are probably multiple ways this can be addressed, but I went with `inspect`ing the list after all individual elements were encoded. This way it'll be visible that something isn't right and no data will go unredacted.

Oh, and my personal real world example where the redactor was crashing is when I tried to log [`Plug.Conn.resp_body`](https://hexdocs.pm/plug/Plug.Conn.html#t:t/0), which is of iodata type and is often an improper list.

Let me know what you think!