### PR TITLE
Format `metadata[:file]` as string in `Formatters.Basic`

### DIFF
--- a/lib/logger_json/formatters/basic.ex
+++ b/lib/logger_json/formatters/basic.ex
@@ -56,12 +56,17 @@ defmodule LoggerJSON.Formatters.Basic do
         crash: &format_crash_reason(&1, &2, meta)
       })
 
+    metadata =
+      meta
+      |> take_metadata(metadata_selector)
+      |> maybe_update(:file, &IO.chardata_to_string/1)
+
     line =
       %{
         time: utc_time(meta),
         severity: Atom.to_string(level),
         message: encode(message, redactors),
-        metadata: encode(take_metadata(meta, metadata_selector), redactors)
+        metadata: encode(metadata, redactors)
       }
       |> maybe_put(:request, format_http_request(meta))
       |> maybe_put(:span, format_span(meta))

--- a/test/logger_json/formatters/basic_test.exs
+++ b/test/logger_json/formatters/basic_test.exs
@@ -124,7 +124,7 @@ defmodule LoggerJSON.Formatters.BasicTest do
       |> decode_or_print_error()
       |> Map.get("metadata")
 
-    assert metadata |> Map.get("file") |> to_string() =~ "logger_json/formatters/basic_test.exs"
+    assert metadata |> Map.get("file") =~ "logger_json/formatters/basic_test.exs"
     assert metadata |> Map.get("line") |> is_integer()
 
     assert metadata["mfa"] === "Elixir.LoggerJSON.Formatters.BasicTest.test logs file, line and mfa as metadata/1"


### PR DESCRIPTION
Erlang passes `metadata[:file]` as a charlist, which is passed as is by `Basic` formatter. In this PR I changed `Basic` formatter to output the file as a string.

Resolves #158.