### PR TITLE
Add indentation to the code snippet for docs

### DIFF
--- a/lib/logger_json/formatter.ex
+++ b/lib/logger_json/formatter.ex
@@ -23,8 +23,8 @@ defmodule LoggerJSON.Formatter do
   the first element is the module implementing `LoggerJSON.Formatter`,
   and the second is the options passed to `new/1`. For example:
 
-    config :logger, :default_handler,
-      formatter: {LoggerJSON.Formatters.Basic, metadata: [:request_id]}
+      config :logger, :default_handler,
+        formatter: {LoggerJSON.Formatters.Basic, metadata: [:request_id]}
 
   Note that tuple‑based configs are resolved for each log entry,
   which can increase logging overhead.


### PR DESCRIPTION
Currently the code snippet is not rendered correctly because of the indentation:

https://hexdocs.pm/logger_json/7.0.3/LoggerJSON.Formatter.html#c:new/1

<img width="888" alt="Screenshot 2025-05-23 at 21 54 45" src="https://github.com/user-attachments/assets/6447ecdf-fc97-4921-8d8a-15ae22f8600f" />

