### PR TITLE
fix(google-cloud): format-affected-user/1 with non-binary values

### DIFF
--- a/lib/logger_json/formatters/google_cloud.ex
+++ b/lib/logger_json/formatters/google_cloud.ex
@@ -329,10 +329,10 @@ defmodule LoggerJSON.Formatters.GoogleCloud do
     end
   end
 
-  defp format_affected_user(%{user_id: user_id}), do: "user:" <> user_id
-  defp format_affected_user(%{identity_id: identity_id}), do: "identity:" <> identity_id
-  defp format_affected_user(%{actor_id: actor_id}), do: "actor:" <> actor_id
-  defp format_affected_user(%{account_id: account_id}), do: "account:" <> account_id
+  defp format_affected_user(%{user_id: user_id}), do: Enum.join(["user:", user_id])
+  defp format_affected_user(%{identity_id: identity_id}), do: Enum.join(["identity:", identity_id])
+  defp format_affected_user(%{actor_id: actor_id}), do: Enum.join(["actor:", actor_id])
+  defp format_affected_user(%{account_id: account_id}), do: Enum.join(["account:", account_id])
   defp format_affected_user(_meta), do: nil
 
   defp format_stacktrace(stacktrace) do


### PR DESCRIPTION
### 🐞 Problem  
The `google_cloud` formatter crashes when it receives a crash log where the `user context` contains values that are not binaries (e.g., integers). This happens because the formatter uses the `<>` operator for string concatenation, which raises an error when used with non-binary types.

**Truncated example of a crashed log:**

```bash
2025-01-01T01:01:01.000000+00:00 error: FORMATTER CRASH: {string,<<"** (Postgrex.Error) ERROR 428...
```

### ✅ Solution  
This PR replaces the use of the `<>` operator with `Enum.join/2` when formatting key-value pairs. This approach safely converts all values to strings before concatenation, preventing crashes when values are not binaries.