### PR TITLE
fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Additionally, you may also be try [redirecting otp reports to Logger](https://he
 ## Configuration
 
 Configuration can be set using 2nd element of the tuple of the `:formatter` option in `Logger` configuration.
-For example in `config.exs`:
+For example in `runtime.exs`:
 
 ```elixir
 config :logger, :default_handler,

--- a/lib/logger_json.ex
+++ b/lib/logger_json.ex
@@ -52,7 +52,7 @@ defmodule LoggerJSON do
   Configuration can be set using `new/1` helper of the formatter module,
   or by setting the 2nd element of the `:formatter` option tuple in `Logger` configuration.
 
-  For example in `config.exs`:
+  For example in `runtime.exs`:
 
       config :logger, :default_handler,
         formatter: LoggerJSON.Formatters.GoogleCloud.new(metadata: :all, project_id: "logger-101")


### PR DESCRIPTION
Hi. I tried running the following snippet from docs and got the error. According to earlier docs `config.exs` does not allow calling `new/1` function.
```
  ** (UndefinedFunctionError) function LoggerJSON.Formatters.GoogleCloud.new/1 is undefined (module LoggerJSON.Formatters.GoogleCloud is not available)
      LoggerJSON.Formatters.GoogleCloud.new([metadata: :all, project_id: "logger-101"])
```

Not sure if the following line should change as well since my change is to rename `config.exs` to `runtime.exs` which is for runtime too.
<img width="682" alt="Screenshot 2025-07-09 at 10 49 18 PM" src="https://github.com/user-attachments/assets/c8342f55-8a52-452c-a2b8-7840b45c4578" />
