### PR TITLE
Support special metadata keys :module and :function

### DIFF
--- a/lib/logger_json/formatter/metadata.ex
+++ b/lib/logger_json/formatter/metadata.ex
@@ -66,6 +66,27 @@ defmodule LoggerJSON.Formatter.Metadata do
   end
 
   def take_metadata(meta, keys) when is_list(keys) do
-    Map.take(meta, keys)
+    Enum.reduce(keys, %{}, &compute_meta(&1, &2, meta))
+  end
+
+  defp compute_meta(:module, acc, meta) do
+    case meta do
+      %{mfa: {mod, _, _}} -> Map.put(acc, :module, inspect(mod))
+      _ -> acc
+    end
+  end
+
+  defp compute_meta(:function, acc, meta) do
+    case meta do
+      %{mfa: {_, fun, arity}} -> Map.put(acc, :function, "#{fun}/#{arity}")
+      _ -> acc
+    end
+  end
+
+  defp compute_meta(key, acc, meta) do
+    case meta do
+      %{^key => value} -> Map.put(acc, key, value)
+      _ -> acc
+    end
   end
 end

--- a/test/logger_json/formatter/metadata_test.exs
+++ b/test/logger_json/formatter/metadata_test.exs
@@ -114,5 +114,14 @@ defmodule LoggerJSON.Formatter.MetadataTest do
 
       assert take_metadata(meta, [:mfa]) == %{mfa: "mfa"}
     end
+
+    test "supports special metadata keys :module and :function" do
+      meta = %{
+        mfa: {Foo.Bar, :foo, 7}
+      }
+
+      assert take_metadata(meta, [:module]) == %{module: "Foo.Bar"}
+      assert take_metadata(meta, [:function]) == %{function: "foo/7"}
+    end
   end
 end


### PR DESCRIPTION
These are described in the [Logger module documentation] as extracting parts of the :mfa metadata provided automatically by Logger.

[Logger module documentation]: https://hexdocs.pm/logger/1.18.4/Logger.html#module-metadata

We'd like to have all our application's logs annotated with the module metadata in particular. This works for the console formatter but not with logger_json, which we use for exporting prod logs to a third party provider.