### PR TITLE
fix(datadog): Non-map values for error key

### DIFF
--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -263,9 +263,15 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   defp format_error(%{message: message}, metadata, level, reported_levels) when is_binary(message) do
     if level in reported_levels do
+      metadata_error =
+        case metadata[:error] do
+          nil -> %{}
+          value when is_map(value) -> value
+          other -> %{error: other}
+        end
+
       error =
-        metadata[:error]
-        |> Kernel.||(%{})
+        metadata_error
         |> Map.put(:kind, get_error_kind(metadata))
         |> Map.put(:message, message)
         |> maybe_put(:stack, get_error_stack(metadata))

--- a/test/logger_json/formatters/datadog_test.exs
+++ b/test/logger_json/formatters/datadog_test.exs
@@ -489,6 +489,20 @@ defmodule LoggerJSON.Formatters.DatadogTest do
     end
   end
 
+  test "logs non-map error field from logger metadata as error.error" do
+    for level <- [:error, :critical, :alert, :emergency] do
+      log =
+        capture_log(level, fn ->
+          Logger.log(level, "Something went wrong", error: "Error field")
+        end)
+        |> decode_or_print_error()
+
+      assert log["error"]["kind"] == "error"
+      assert log["error"]["message"] == "Something went wrong"
+      assert log["error"]["error"] == "Error field"
+    end
+  end
+
   if @encoder == Jason do
     test "passing options to encoder" do
       formatter = Datadog.new(encoder_opts: [pretty: true])


### PR DESCRIPTION
Passing an `error` key is a really easy footgun:

```elixir
Logger.error("Something bad happened", error: "{:error, :something_bad}")
```

Currently, the formatter crashes because it expects `error` to be a map. This PR fixes the issue by assuming the caller was not trying to define the error map, and instead nests the value _inside_ the error map:

```elixir
%{
  error: %{
    kind: "error",
    message: "Something bad happened",
    error: "{:error, :something_bad}"
  }
}
```