### PR TITLE
Add support for syslog.env to Datadog formatter

### DIFF
--- a/test/logger_json/formatters/datadog_test.exs
+++ b/test/logger_json/formatters/datadog_test.exs
@@ -117,6 +117,29 @@ defmodule LoggerJSON.Formatters.DatadogTest do
     refute Map.has_key?(log["syslog"], "hostname")
   end
 
+  test "logs env" do
+    # do not log it by default
+    log =
+      capture_log(fn ->
+        Logger.debug("Hello")
+      end)
+      |> decode_or_print_error()
+
+    refute Map.has_key?(log["syslog"], "env")
+
+    # static value
+    formatter = Datadog.new(env: "production")
+    :logger.update_handler_config(:default, :formatter, formatter)
+
+    log =
+      capture_log(fn ->
+        Logger.debug("Hello")
+      end)
+      |> decode_or_print_error()
+
+    assert log["syslog"]["env"] == "production"
+  end
+
   test "logs OpenTelemetry span and trace ids" do
     Logger.metadata(
       otel_span_id: ~c"bff20904aa5883a6",


### PR DESCRIPTION
In addition to the already populated `syslog.hostname`, `syslog.severity` and `syslog.timestamp`, [Datadog also supports `syslog.env` value](https://docs.datadoghq.com/standard-attributes/?search=syslog&product=log+management). However, there is currently no way to inject it using `LoggerJSON.Formatters.Datadog` without implementing a custom formatter which will `IO.iodata_to_binary()` and then `Jason.encode_to_iodata!()`.

This PR is a proposal to supports a new `:env` configuration key, which defaults to `nil`, which can be injected at configuration time.