### PR TITLE
Use pin operator when matching binary in formatters/datadog.ex

### DIFF
--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -227,7 +227,7 @@ defmodule LoggerJSON.Formatters.Datadog do
   defp convert_otel_field(value) when is_binary(value) or is_list(value) do
     value = to_string(value)
     len = byte_size(value) - 16
-    <<_front::binary-size(len), value::binary>> = value
+    <<_front::binary-size(^len), value::binary>> = value
     convert_otel_field(value)
   rescue
     _ -> ""


### PR DESCRIPTION
When compiled under Elixir 1.20, there is following warning:

     warning: the variable "len" is accessed inside size(...) of a bitstring but it was defined outside of the match. You must precede it with the pin operator
     │
 230 │     <<_front::binary-size(len), value::binary>> = value
     │                           ~
     │
     └─ lib/logger_json/formatters/datadog.ex:230:27: LoggerJSON.Formatters.Datadog.convert_otel_field/1