### PR TITLE
perf: memoize Datadog hostname and drop redundant metadata copy

### DIFF
--- a/lib/logger_json/formatter/metadata.ex
+++ b/lib/logger_json/formatter/metadata.ex
@@ -50,15 +50,11 @@ defmodule LoggerJSON.Formatter.Metadata do
     the ones already processed by the formatter.
   """
   def take_metadata(meta, {:all_except, keys}) do
-    meta
-    |> Map.drop(keys ++ @ignored_metadata_keys)
-    |> Enum.into(%{})
+    Map.drop(meta, keys ++ @ignored_metadata_keys)
   end
 
   def take_metadata(meta, :all) do
-    meta
-    |> Map.drop(@ignored_metadata_keys)
-    |> Enum.into(%{})
+    Map.drop(meta, @ignored_metadata_keys)
   end
 
   def take_metadata(_meta, []) do

--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -66,7 +66,7 @@ defmodule LoggerJSON.Formatters.Datadog do
     opts = Keyword.new(opts)
     encoder_opts = Keyword.get_lazy(opts, :encoder_opts, &Formatter.default_encoder_opts/0)
     redactors = Keyword.get(opts, :redactors, [])
-    hostname = Keyword.get(opts, :hostname, :system)
+    hostname = opts |> Keyword.get(:hostname, :system) |> syslog_hostname()
     metadata_keys_or_selector = Keyword.get(opts, :metadata, [])
     metadata_selector = update_metadata_selector(metadata_keys_or_selector, @processed_metadata_keys)
     reported_levels = Keyword.get(opts, :reported_levels, @default_levels_reported_as_errors)
@@ -175,7 +175,7 @@ defmodule LoggerJSON.Formatters.Datadog do
       severity: Atom.to_string(level),
       timestamp: utc_time(meta)
     }
-    |> maybe_put(:hostname, syslog_hostname(hostname))
+    |> maybe_put(:hostname, hostname)
     |> maybe_put(:env, env)
   end
 


### PR DESCRIPTION
Two hot-path optimizations in the log formatters.

Datadog: resolve the hostname once at config time instead of on every log line. `:inet.gethostname/0` is a round-trip to the inet_db port and a node's hostname does not change at runtime.

Metadata: `take_metadata/2` piped `Map.drop/2` into `Enum.into(%{})`. `Map.drop/2` already returns a map, so `Enum.into(%{})` rebuilt the whole map a second time for nothing — an extra O(n) pass and allocation on every log line. Removed from both the `{:all_except, keys}` and `:all` clauses.