### PR TITLE
fix(datadog): Encode metadata error value before embedding in error field

### DIFF
--- a/lib/logger_json/formatters/datadog.ex
+++ b/lib/logger_json/formatters/datadog.ex
@@ -111,7 +111,7 @@ defmodule LoggerJSON.Formatters.Datadog do
       %{syslog: syslog(level, meta, hostname, env)}
       |> maybe_put(:logger, format_logger(meta))
       |> maybe_merge(format_http_request(meta))
-      |> maybe_merge(format_error(message, metadata, level, reported_levels))
+      |> maybe_merge(format_error(message, metadata, level, reported_levels, redactors))
       |> maybe_merge(encode(metadata, redactors))
       |> maybe_merge(encode(message, redactors))
       |> @encoder.encode_to_iodata!(encoder_opts)
@@ -255,15 +255,15 @@ defmodule LoggerJSON.Formatters.Datadog do
 
   defp format_http_request(_meta), do: nil
 
-  defp format_error(%{error: _error}, _metadata, _level, _reported_levels), do: nil
+  defp format_error(%{error: _error}, _metadata, _level, _reported_levels, _redactors), do: nil
 
-  defp format_error(%{message: message}, metadata, level, reported_levels) when is_binary(message) do
+  defp format_error(%{message: message}, metadata, level, reported_levels, redactors) when is_binary(message) do
     if level in reported_levels do
       metadata_error =
         case metadata[:error] do
           nil -> %{}
-          value when is_map(value) -> value
-          other -> %{error: other}
+          value when is_map(value) -> encode(value, redactors)
+          other -> %{error: encode(other, redactors)}
         end
 
       error =
@@ -276,7 +276,7 @@ defmodule LoggerJSON.Formatters.Datadog do
     end
   end
 
-  defp format_error(_msg, _metadata, _level, _reported_levels), do: nil
+  defp format_error(_msg, _metadata, _level, _reported_levels, _redactors), do: nil
 
   defp get_error_kind(%{error: %{kind: kind}}) when is_binary(kind), do: kind
   defp get_error_kind(_metadata), do: "error"

--- a/test/logger_json/formatters/datadog_test.exs
+++ b/test/logger_json/formatters/datadog_test.exs
@@ -526,6 +526,35 @@ defmodule LoggerJSON.Formatters.DatadogTest do
     end
   end
 
+  test "encodes error field from logger metadata that is not JSON-encodable" do
+    for level <- [:error, :critical, :alert, :emergency] do
+      log =
+        capture_log(level, fn ->
+          Logger.log(level, "Something went wrong", error: {:error, {:timeout, {GenServer, :call, [:server, :msg]}}})
+        end)
+        |> decode_or_print_error()
+
+      assert log["error"]["kind"] == "error"
+      assert log["error"]["message"] == "Something went wrong"
+      assert log["error"]["error"] == ["error", ["timeout", ["Elixir.GenServer", "call", ["server", "msg"]]]]
+    end
+  end
+
+  test "encodes map error field from logger metadata with values that are not JSON-encodable" do
+    for level <- [:error, :critical, :alert, :emergency] do
+      log =
+        capture_log(level, fn ->
+          Logger.log(level, "Something went wrong", error: %{module: "PaymentGateway", reason: {:error, :timeout}})
+        end)
+        |> decode_or_print_error()
+
+      assert log["error"]["kind"] == "error"
+      assert log["error"]["message"] == "Something went wrong"
+      assert log["error"]["module"] == "PaymentGateway"
+      assert log["error"]["reason"] == ["error", "timeout"]
+    end
+  end
+
   if @encoder == Jason do
     test "passing options to encoder" do
       formatter = Datadog.new(encoder_opts: [pretty: true])


### PR DESCRIPTION
`format_error/4` embeds the raw metadata `:error` value into the log line, bypassing `RedactorEncoder`. A non-JSON-encodable term (e.g. an `{:error, reason}` tuple) then crashes the encoder.

This fix runs the value through `encode/2` (which also applies redactors), matching how every other part of the line is built.